### PR TITLE
Downgrade eks instance types staging

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -95,7 +95,7 @@ variable "mongodb_apps_node_group_desired_size" {
 
 variable "apps_node_group_instance_types" {
   type    = string
-  default = "m5a.xlarge"
+  default = "r5a.large"
 }
 variable "apps_node_group_min_size" {
   type    = number
@@ -112,7 +112,7 @@ variable "apps_node_group_desired_size" {
 
 variable "webapps_node_group_instance_types" {
   type    = string
-  default = "m5a.xlarge"
+  default = "r5a.large"
 }
 variable "webapps_node_group_min_size" {
   type    = number
@@ -129,7 +129,7 @@ variable "webapps_node_group_desired_size" {
 
 variable "gfw_node_group_instance_types" {
   type    = string
-  default = "m5a.xlarge"
+  default = "r5a.large"
 }
 variable "gfw_node_group_min_size" {
   type    = number
@@ -163,7 +163,7 @@ variable "gfw_pro_node_group_desired_size" {
 
 variable "core_node_group_instance_types" {
   type    = string
-  default = "m5a.xlarge"
+  default = "r5a.large"
 }
 variable "core_node_group_min_size" {
   type    = number


### PR DESCRIPTION
After all the cherry picking, it was just four lines of code to change, so I just redid the changes in a new commit 😛 

- Downgrade EKS instance types from `m5a.xlarge` to `r5a.large` for the following node groups (other node groups excluded based on CPU usage or the fact that they've already been optimized):
    - `apps-node-group`
    - `webapps-node-group`
    - `gfw-node-group`
    - `core-node-group`
