### PR TITLE
Change EKS instance types from m5a.large to c5a.xlarge

### DIFF
--- a/terraform/modules/node_group/main.tf
+++ b/terraform/modules/node_group/main.tf
@@ -20,7 +20,8 @@ resource "aws_eks_node_group" "eks-node-group" {
   ]
 
   lifecycle {
-    ignore_changes = [scaling_config[0].desired_size]
+    ignore_changes        = [scaling_config[0].desired_size]
+    create_before_destroy = true
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -95,7 +95,7 @@ variable "mongodb_apps_node_group_desired_size" {
 
 variable "apps_node_group_instance_types" {
   type    = string
-  default = "r5a.large"
+  default = "c5a.xlarge"
 }
 variable "apps_node_group_min_size" {
   type    = number
@@ -116,7 +116,7 @@ variable "apps_node_group_min_size_upscaled" {
 
 variable "webapps_node_group_instance_types" {
   type    = string
-  default = "r5a.large"
+  default = "c5a.xlarge"
 }
 variable "webapps_node_group_min_size" {
   type    = number
@@ -133,7 +133,7 @@ variable "webapps_node_group_desired_size" {
 
 variable "gfw_node_group_instance_types" {
   type    = string
-  default = "r5a.large"
+  default = "c5a.xlarge"
 }
 variable "gfw_node_group_min_size" {
   type    = number
@@ -171,7 +171,7 @@ variable "gfw_pro_node_group_desired_size" {
 
 variable "core_node_group_instance_types" {
   type    = string
-  default = "r5a.large"
+  default = "c5a.xlarge"
 }
 variable "core_node_group_min_size" {
   type    = number


### PR DESCRIPTION
Change EKS instance types from m5a.large to c5a.xlarge on recommendation from @tiagojsag and @ikas. Sounds like we should have switched to c5a.xlarge in the first place, but I got confused with a recommendation from AWS and switched to the wrong instance type.