### PR TITLE
Update terraform production settings to match AWS state

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -120,7 +120,7 @@ variable "webapps_node_group_min_size" {
 }
 variable "webapps_node_group_max_size" {
   type    = number
-  default = 4
+  default = 6
 }
 variable "webapps_node_group_desired_size" {
   type    = number

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -14,3 +14,7 @@ terraform {
   }
   required_version = "0.13.3"
 }
+
+provider "aws" {
+  region = var.aws_region
+}


### PR DESCRIPTION
Due to unrelated, temporary changes I have since reverted, I needed to run "tf apply" on the prod cluster. To get the TF files to match the AWS / TF state, I had to make the changed below. I'm leaving them here in case you want to review and merge them, assuming we want to have TF code and the actual state to be a perfect match.