### PR TITLE
Revert "Deactivate Container Insights but keep the config"

### DIFF
--- a/terraform-k8s-infrastructure/modules/k8s_infrastructure/main.tf
+++ b/terraform-k8s-infrastructure/modules/k8s_infrastructure/main.tf
@@ -44,9 +44,9 @@ resource "kubectl_manifest" "metrics-server" {
 // https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html
 // Container insights
 // File has changes - see link above for details
-# resource "kubectl_manifest" "container_insights" {
-#   yaml_body = templatefile("${path.module}/container_insights/container_insights.yaml.tmpl", {
-#     aws_region : var.aws_region,
-#     cluster_name : var.cluster_name
-#   })
-# }
+resource "kubectl_manifest" "container_insights" {
+  yaml_body = templatefile("${path.module}/container_insights/container_insights.yaml.tmpl", {
+    aws_region : var.aws_region,
+    cluster_name : var.cluster_name
+  })
+}


### PR DESCRIPTION
Reverts resource-watch/api-infrastructure#93 - accidentally turned off the logs themselves in addition to turning off the metrics.