### PR TITLE
Add kube-proxy as add-on compatible with kubernetes 1.30

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -54,6 +54,7 @@ module "eks" {
   eks_version           = var.eks_version
   aws_region            = var.aws_region
   ebs_csi_addon_version = var.ebs_csi_addon_version
+  kube_proxy_addon_version = var.kube_proxy_addon_version
   admin_role_arns       = data.aws_iam_roles.admin_arn.arns
   subnet_ids = [
     module.vpc.private_subnets[0].id,

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -44,6 +44,12 @@ resource "aws_eks_addon" "aws_ebs_csi_driver" {
   service_account_role_arn = aws_iam_role.ebs_csi_iam_role.arn
 }
 
+resource "aws_eks_addon" "kube_proxy" {
+  cluster_name             = aws_eks_cluster.eks_cluster.name
+  addon_name               = "kube-proxy"
+  addon_version            = var.kube_proxy_addon_version
+}
+
 resource "aws_security_group" "eks_cluster_security_group" {
   name        = "${replace(var.project, " ", "-")}eks-cluster-security-group"
   description = "Cluster communication with worker nodes"

--- a/terraform/modules/eks/variable.tf
+++ b/terraform/modules/eks/variable.tf
@@ -30,6 +30,11 @@ variable "ebs_csi_addon_version" {
   description = "Version of AWS EBS CRI driver to use"
 }
 
+variable "kube_proxy_addon_version" {
+  type        = string
+  description = "Version of kube-proxy to use"
+} 
+
 variable "backups_bucket" {
   type        = string
   description = "S3 bucket to which backups will be performed"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -241,6 +241,11 @@ variable "ebs_csi_addon_version" {
   description = "Version of AWS EBS CRI driver to use"
 }
 
+variable "kube_proxy_addon_version" {
+  type        = string
+  description = "Version of kube-proxy to use"
+} 
+
 variable "hibernate" {
   description = "If set to true, the EKS cluster will be scaled down and its services unavailable"
   type        = bool

--- a/terraform/vars/terraform-dev.tfvars
+++ b/terraform/vars/terraform-dev.tfvars
@@ -13,6 +13,7 @@ db_logs_exports          = ["audit", "profiler"]
 eks_version              = "1.30"
 # eks_node_release_version = "1.29.0-20240202"
 ebs_csi_addon_version    = "v1.30.0-eksbuild.1"
+kube_proxy_addon_version = "v1.30.14-eksbuild.18"
 # apps_node_group_min_size          = 1
 # apps_node_group_max_size          = 16
 # apps_node_group_desired_size      = 3


### PR DESCRIPTION
Add kube-proxy as add-on compatible with kubernetes 1.30.

This should fiz the error below:

<img width="1815" height="181" alt="image" src="https://github.com/user-attachments/assets/bd36096e-3570-47f6-9dbe-beedb8d9a891" />
