### PR TITLE
Update pg and rabbit vendor charts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,4 @@
+# PVC Debugger
+
+export PVC_NAME=<my-pvc-name>
+envsubst < pvc-debugger.yaml | kubectl apply -n <namespace> -f -

--- a/scripts/pvc-debugger.yaml
+++ b/scripts/pvc-debugger.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-debugger
+spec:
+  volumes:
+    - name: volume-to-debug
+      persistentVolumeClaim:
+        claimName: ${PVC_NAME} # Replace with your PVC name
+  containers:
+    - name: debugger
+      image: busybox:stable
+      command: ['sleep', '3600'] # Keeps the pod running
+      volumeMounts:
+        - mountPath: "/data" # The path where the volume will be mounted
+          name: volume-to-debug
+  restartPolicy: Never

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/Chart.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+name: postgresql
+version: 8.6.4
+appVersion: 11.7.0
+description: Chart for PostgreSQL, an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
+keywords:
+  - postgresql
+  - postgres
+  - database
+  - sql
+  - replication
+  - cluster
+home: https://www.postgresql.org/
+icon: https://bitnami.com/assets/stacks/postgresql/img/postgresql-stack-110x117.png
+sources:
+  - https://github.com/bitnami/bitnami-docker-postgresql
+maintainers:
+  - name: Bitnami
+    email: containers@bitnami.com
+  - name: desaintmartin
+    email: cedric@desaintmartin.fr
+engine: gotpl

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/README.md
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/README.md
@@ -1,0 +1,567 @@
+# PostgreSQL
+
+[PostgreSQL](https://www.postgresql.org/) is an object-relational database management system (ORDBMS) with an emphasis on extensibility and on standards-compliance.
+
+For HA, please see [this repo](https://github.com/bitnami/charts/tree/master/bitnami/postgresql-ha)
+
+## TL;DR;
+
+```console
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/postgresql
+```
+
+## Introduction
+
+This chart bootstraps a [PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This chart has been tested to work with NGINX Ingress, cert-manager, fluentd and Prometheus on top of the [BKPR](https://kubeprod.io/).
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 2.11+ or Helm 3.0-beta3+
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+To install the chart with the release name `my-release`:
+
+```console
+$ helm install my-release bitnami/postgresql
+```
+
+The command deploys PostgreSQL on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+The following tables lists the configurable parameters of the PostgreSQL chart and their default values.
+
+|                   Parameter                   |                                                                                Description                                                                                |                            Default                            |
+|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| `global.imageRegistry`                        | Global Docker Image registry                                                                                                                                              | `nil`                                                         |
+| `global.postgresql.postgresqlDatabase`        | PostgreSQL database (overrides `postgresqlDatabase`)                                                                                                                      | `nil`                                                         |
+| `global.postgresql.postgresqlUsername`        | PostgreSQL username (overrides `postgresqlUsername`)                                                                                                                      | `nil`                                                         |
+| `global.postgresql.existingSecret`            | Name of existing secret to use for PostgreSQL passwords (overrides `existingSecret`)                                                                                      | `nil`                                                         |
+| `global.postgresql.postgresqlPassword`        | PostgreSQL admin password (overrides `postgresqlPassword`)                                                                                                                | `nil`                                                         |
+| `global.postgresql.servicePort`               | PostgreSQL port (overrides `service.port`)                                                                                                                                | `nil`                                                         |
+| `global.postgresql.replicationPassword`       | Replication user password (overrides `replication.password`)                                                                                                              | `nil`                                                         |
+| `global.imagePullSecrets`                     | Global Docker registry secret names as an array                                                                                                                           | `[]` (does not add image pull secrets to deployed pods)       |
+| `global.storageClass`                         | Global storage class for dynamic provisioning                                                                                                                             | `nil`                                                         |
+| `image.registry`                              | PostgreSQL Image registry                                                                                                                                                 | `docker.io`                                                   |
+| `image.repository`                            | PostgreSQL Image name                                                                                                                                                     | `bitnami/postgresql`                                          |
+| `image.tag`                                   | PostgreSQL Image tag                                                                                                                                                      | `{TAG_NAME}`                                                  |
+| `image.pullPolicy`                            | PostgreSQL Image pull policy                                                                                                                                              | `IfNotPresent`                                                |
+| `image.pullSecrets`                           | Specify Image pull secrets                                                                                                                                                | `nil` (does not add image pull secrets to deployed pods)      |
+| `image.debug`                                 | Specify if debug values should be set                                                                                                                                     | `false`                                                       |
+| `nameOverride`                                | String to partially override postgresql.fullname template with a string (will prepend the release name)                                                                   | `nil`                                                         |
+| `fullnameOverride`                            | String to fully override postgresql.fullname template with a string                                                                                                       | `nil`                                                         |
+| `volumePermissions.enabled`                   | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)                 | `false`                                                       |
+| `volumePermissions.image.registry`            | Init container volume-permissions image registry                                                                                                                          | `docker.io`                                                   |
+| `volumePermissions.image.repository`          | Init container volume-permissions image name                                                                                                                              | `bitnami/minideb`                                             |
+| `volumePermissions.image.tag`                 | Init container volume-permissions image tag                                                                                                                               | `buster`                                                      |
+| `volumePermissions.image.pullPolicy`          | Init container volume-permissions image pull policy                                                                                                                       | `Always`                                                      |
+| `volumePermissions.securityContext.runAsUser` | User ID for the init container (when facing issues in OpenShift or uid unknown, try value "auto")                                                                         | `0`                                                           |
+| `usePasswordFile`                             | Have the secrets mounted as a file instead of env vars                                                                                                                    | `false`                                                       |
+| `ldap.enabled`                                | Enable LDAP support                                                                                                                                                       | `false`                                                       |
+| `ldap.existingSecret`                         | Name of existing secret to use for LDAP passwords                                                                                                                         | `nil`                                                         |
+| `ldap.url`                                    | LDAP URL beginning in the form `ldap[s]://host[:port]/basedn[?[attribute][?[scope][?[filter]]]]`                                                                          | `nil`                                                         |
+| `ldap.server`                                 | IP address or name of the LDAP server.                                                                                                                                    | `nil`                                                         |
+| `ldap.port`                                   | Port number on the LDAP server to connect to                                                                                                                              | `nil`                                                         |
+| `ldap.scheme`                                 | Set to `ldaps` to use LDAPS.                                                                                                                                              | `nil`                                                         |
+| `ldap.tls`                                    | Set to `1` to use TLS encryption                                                                                                                                          | `nil`                                                         |
+| `ldap.prefix`                                 | String to prepend to the user name when forming the DN to bind                                                                                                            | `nil`                                                         |
+| `ldap.suffix`                                 | String to append to the user name when forming the DN to bind                                                                                                             | `nil`                                                         |
+| `ldap.search_attr`                            | Attribute to match agains the user name in the search                                                                                                                     | `nil`                                                         |
+| `ldap.search_filter`                          | The search filter to use when doing search+bind authentication                                                                                                            | `nil`                                                         |
+| `ldap.baseDN`                                 | Root DN to begin the search for the user in                                                                                                                               | `nil`                                                         |
+| `ldap.bindDN`                                 | DN of user to bind to LDAP                                                                                                                                                | `nil`                                                         |
+| `ldap.bind_password`                          | Password for the user to bind to LDAP                                                                                                                                     | `nil`                                                         |
+| `replication.enabled`                         | Enable replication                                                                                                                                                        | `false`                                                       |
+| `replication.user`                            | Replication user                                                                                                                                                          | `repl_user`                                                   |
+| `replication.password`                        | Replication user password                                                                                                                                                 | `repl_password`                                               |
+| `replication.slaveReplicas`                   | Number of slaves replicas                                                                                                                                                 | `1`                                                           |
+| `replication.synchronousCommit`               | Set synchronous commit mode. Allowed values: `on`, `remote_apply`, `remote_write`, `local` and `off`                                                                      | `off`                                                         |
+| `replication.numSynchronousReplicas`          | Number of replicas that will have synchronous replication. Note: Cannot be greater than `replication.slaveReplicas`.                                                      | `0`                                                           |
+| `replication.applicationName`                 | Cluster application name. Useful for advanced replication settings                                                                                                        | `my_application`                                              |
+| `existingSecret`                              | Name of existing secret to use for PostgreSQL passwords. The secret has to contain the keys `postgresql-postgres-password` which is the password for `postgresqlUsername` when it is different of `postgres`, `postgresql-password` which will override `postgresqlPassword`, `postgresql-replication-password` which will override `replication.password` and `postgresql-ldap-password` which will be sed to authenticate on LDAP.                                                                                                                   | `nil`                                                         |
+| `postgresqlPostgresPassword`                  | PostgreSQL admin password (used when `postgresqlUsername` is not `postgres`)                                                                                              | _random 10 character alphanumeric string_                     |
+| `postgresqlUsername`                          | PostgreSQL admin user                                                                                                                                                     | `postgres`                                                    |
+| `postgresqlPassword`                          | PostgreSQL admin password                                                                                                                                                 | _random 10 character alphanumeric string_                     |
+| `postgresqlDatabase`                          | PostgreSQL database                                                                                                                                                       | `nil`                                                         |
+| `postgresqlDataDir`                           | PostgreSQL data dir folder                                                                                                                                                | `/bitnami/postgresql` (same value as persistence.mountPath)   |
+| `extraEnv`                                    | Any extra environment variables you would like to pass on to the pod. The value is evaluated as a template.                                                               | `[]`                                                          |
+| `extraEnvVarsCM`                              | Name of a Config Map containing extra environment variables you would like to pass on to the pod.                                                                         | `nil`                                                         |
+| `postgresqlInitdbArgs`                        | PostgreSQL initdb extra arguments                                                                                                                                         | `nil`                                                         |
+| `postgresqlInitdbWalDir`                      | PostgreSQL location for transaction log                                                                                                                                   | `nil`                                                         |
+| `postgresqlConfiguration`                     | Runtime Config Parameters                                                                                                                                                 | `nil`                                                         |
+| `postgresqlExtendedConf`                      | Extended Runtime Config Parameters (appended to main or default configuration)                                                                                            | `nil`                                                         |
+| `pgHbaConfiguration`                          | Content of pg_hba.conf                                                                                                                                                    | `nil (do not create pg_hba.conf)`                             |
+| `configurationConfigMap`                      | ConfigMap with the PostgreSQL configuration files (Note: Overrides `postgresqlConfiguration` and `pgHbaConfiguration`). The value is evaluated as a template.             | `nil`                                                         |
+| `extendedConfConfigMap`                       | ConfigMap with the extended PostgreSQL configuration files. The value is evaluated as a template.                                                                         | `nil`                                                         |
+| `initdbScripts`                               | Dictionary of initdb scripts                                                                                                                                              | `nil`                                                         |
+| `initdbUsername`                              | PostgreSQL user to execute the .sql and sql.gz scripts                                                                                                                    | `nil`                                                         |
+| `initdbPassword`                              | Password for the user specified in `initdbUsername`                                                                                                                       | `nil`                                                         |
+| `initdbScriptsConfigMap`                      | ConfigMap with the initdb scripts (Note: Overrides `initdbScripts`). The value is evaluated as a template.                                                                | `nil`                                                         |
+| `initdbScriptsSecret`                         | Secret with initdb scripts that contain sensitive information (Note: can be used with `initdbScriptsConfigMap` or `initdbScripts`). The value is evaluated as a template. | `nil`                                                         |
+| `service.type`                                | Kubernetes Service type                                                                                                                                                   | `ClusterIP`                                                   |
+| `service.port`                                | PostgreSQL port                                                                                                                                                           | `5432`                                                        |
+| `service.nodePort`                            | Kubernetes Service nodePort                                                                                                                                               | `nil`                                                         |
+| `service.annotations`                         | Annotations for PostgreSQL service, the value is evaluated as a template.                                                                                                 | {}                                                            |
+| `service.loadBalancerIP`                      | loadBalancerIP if service type is `LoadBalancer`                                                                                                                          | `nil`                                                         |
+| `service.loadBalancerSourceRanges`            | Address that are allowed when svc is LoadBalancer                                                                                                                         | []                                                            |
+| `schedulerName`                               | Name of the k8s scheduler (other than default)                                                                                                                            | `nil`                                                         |
+| `shmVolume.enabled`                           | Enable emptyDir volume for /dev/shm for master and slave(s) Pod(s)                                                                                                        | `true`                                                        |
+| `shmVolume.chmod.enabled`                     | Run at init chmod 777 of the /dev/shm (ignored if `volumePermissions.enabled` is `false`)                                                                                 | `true`                                                        |
+| `persistence.enabled`                         | Enable persistence using PVC                                                                                                                                              | `true`                                                        |
+| `persistence.existingClaim`                   | Provide an existing `PersistentVolumeClaim`, the value is evaluated as a template.                                                                                        | `nil`                                                         |
+| `persistence.mountPath`                       | Path to mount the volume at                                                                                                                                               | `/bitnami/postgresql`                                         |
+| `persistence.subPath`                         | Subdirectory of the volume to mount at                                                                                                                                    | `""`                                                          |
+| `persistence.storageClass`                    | PVC Storage Class for PostgreSQL volume                                                                                                                                   | `nil`                                                         |
+| `persistence.accessModes`                     | PVC Access Mode for PostgreSQL volume                                                                                                                                     | `[ReadWriteOnce]`                                             |
+| `persistence.size`                            | PVC Storage Request for PostgreSQL volume                                                                                                                                 | `8Gi`                                                         |
+| `persistence.annotations`                     | Annotations for the PVC                                                                                                                                                   | `{}`                                                          |
+| `master.nodeSelector`                         | Node labels for pod assignment (postgresql master)                                                                                                                        | `{}`                                                          |
+| `master.affinity`                             | Affinity labels for pod assignment (postgresql master)                                                                                                                    | `{}`                                                          |
+| `master.tolerations`                          | Toleration labels for pod assignment (postgresql master)                                                                                                                  | `[]`                                                          |
+| `master.anotations`                           | Map of annotations to add to the statefulset (postgresql master)                                                                                                          | `{}`                                                          |
+| `master.labels`                               | Map of labels to add to the statefulset (postgresql master)                                                                                                               | `{}`                                                          |
+| `master.podAnnotations`                       | Map of annotations to add to the pods (postgresql master)                                                                                                                 | `{}`                                                          |
+| `master.podLabels`                            | Map of labels to add to the pods (postgresql master)                                                                                                                      | `{}`                                                          |
+| `master.priorityClassName`                    | Priority Class to use for each pod (postgresql master)                                                                                                                    | `nil`                                                          |
+| `master.extraInitContainers`                  | Additional init containers to add to the pods (postgresql master)                                                                                                         | `[]`                                                          |
+| `master.extraVolumeMounts`                    | Additional volume mounts to add to the pods (postgresql master)                                                                                                           | `[]`                                                          |
+| `master.extraVolumes`                         | Additional volumes to add to the pods (postgresql master)                                                                                                                 | `[]`                                                          |
+| `master.sidecars`                                         | Add additional containers to the pod                                                                                                                          | `[]`                                                     |
+| `slave.nodeSelector`                          | Node labels for pod assignment (postgresql slave)                                                                                                                         | `{}`                                                          |
+| `slave.affinity`                              | Affinity labels for pod assignment (postgresql slave)                                                                                                                     | `{}`                                                          |
+| `slave.tolerations`                           | Toleration labels for pod assignment (postgresql slave)                                                                                                                   | `[]`                                                          |
+| `slave.anotations`                            | Map of annotations to add to the statefulsets (postgresql slave)                                                                                                          | `{}`                                                          |
+| `slave.labels`                                | Map of labels to add to the statefulsets (postgresql slave)                                                                                                               | `{}`                                                          |
+| `slave.podAnnotations`                        | Map of annotations to add to the pods (postgresql slave)                                                                                                                  | `{}`                                                          |
+| `slave.podLabels`                             | Map of labels to add to the pods (postgresql slave)                                                                                                                       | `{}`                                                          |
+| `slave.priorityClassName`                     | Priority Class to use for each pod (postgresql slave)                                                                                                                     | `nil`                                                          |
+| `slave.extraInitContainers`                   | Additional init containers to add to the pods (postgresql slave)                                                                                                          | `[]`                                                          |
+| `slave.extraVolumeMounts`                     | Additional volume mounts to add to the pods (postgresql slave)                                                                                                            | `[]`                                                          |
+| `slave.extraVolumes`                          | Additional volumes to add to the pods (postgresql slave)                                                                                                                  | `[]`                                                          |
+| `slave.sidecars`                                         | Add additional containers to the pod                                                                                                                          | `[]`                                                     |
+| `terminationGracePeriodSeconds`               | Seconds the pod needs to terminate gracefully                                                                                                                             | `nil`                                                         |
+| `resources`                                   | CPU/Memory resource requests/limits                                                                                                                                       | Memory: `256Mi`, CPU: `250m`                                  |
+| `securityContext.enabled`                     | Enable security context                                                                                                                                                   | `true`                                                        |
+| `securityContext.fsGroup`                     | Group ID for the container                                                                                                                                                | `1001`                                                        |
+| `securityContext.runAsUser`                   | User ID for the container                                                                                                                                                 | `1001`                                                        |
+| `serviceAccount.enabled`                      | Enable service account (Note: Service Account will only be automatically created if `serviceAccount.name` is not set)                                                     | `false`                                                       |
+| `serviceAcccount.name`                        | Name of existing service account                                                                                                                                          | `nil`                                                         |
+| `livenessProbe.enabled`                       | Would you like a livenessProbe to be enabled                                                                                                                              | `true`                                                        |
+| `networkPolicy.enabled`                       | Enable NetworkPolicy                                                                                                                                                      | `false`                                                       |
+| `networkPolicy.allowExternal`                 | Don't require client label for connections                                                                                                                                | `true`                                                        |
+| `networkPolicy.explicitNamespacesSelector`    | A Kubernetes LabelSelector to explicitly select namespaces from which ingress traffic could be allowed                                                                    | `nil`                                                         |
+| `livenessProbe.initialDelaySeconds`           | Delay before liveness probe is initiated                                                                                                                                  | 30                                                            |
+| `livenessProbe.periodSeconds`                 | How often to perform the probe                                                                                                                                            | 10                                                            |
+| `livenessProbe.timeoutSeconds`                | When the probe times out                                                                                                                                                  | 5                                                             |
+| `livenessProbe.failureThreshold`              | Minimum consecutive failures for the probe to be considered failed after having succeeded.                                                                                | 6                                                             |
+| `livenessProbe.successThreshold`              | Minimum consecutive successes for the probe to be considered successful after having failed                                                                               | 1                                                             |
+| `readinessProbe.enabled`                      | would you like a readinessProbe to be enabled                                                                                                                             | `true`                                                        |
+| `readinessProbe.initialDelaySeconds`          | Delay before readiness probe is initiated                                                                                                                                 | 5                                                             |
+| `readinessProbe.periodSeconds`                | How often to perform the probe                                                                                                                                            | 10                                                            |
+| `readinessProbe.timeoutSeconds`               | When the probe times out                                                                                                                                                  | 5                                                             |
+| `readinessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded.                                                                                | 6                                                             |
+| `readinessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed                                                                               | 1                                                             |
+| `metrics.enabled`                             | Start a prometheus exporter                                                                                                                                               | `false`                                                       |
+| `metrics.service.type`                        | Kubernetes Service type                                                                                                                                                   | `ClusterIP`                                                   |
+| `service.clusterIP`                           | Static clusterIP or None for headless services                                                                                                                            | `nil`                                                         |
+| `metrics.service.annotations`                 | Additional annotations for metrics exporter pod                                                                                                                           | `{ prometheus.io/scrape: "true", prometheus.io/port: "9187"}` |
+| `metrics.service.loadBalancerIP`              | loadBalancerIP if redis metrics service type is `LoadBalancer`                                                                                                            | `nil`                                                         |
+| `metrics.serviceMonitor.enabled`              | Set this to `true` to create ServiceMonitor for Prometheus operator                                                                                                       | `false`                                                       |
+| `metrics.serviceMonitor.additionalLabels`     | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                                                                     | `{}`                                                          |
+| `metrics.serviceMonitor.namespace`            | Optional namespace in which to create ServiceMonitor                                                                                                                      | `nil`                                                         |
+| `metrics.serviceMonitor.interval`             | Scrape interval. If not set, the Prometheus default scrape interval is used                                                                                               | `nil`                                                         |
+| `metrics.serviceMonitor.scrapeTimeout`        | Scrape timeout. If not set, the Prometheus default scrape timeout is used                                                                                                 | `nil`                                                         |
+| `metrics.prometheusRule.enabled`              | Set this to true to create prometheusRules for Prometheus operator                                                                                                        | `false`                                                       |
+| `metrics.prometheusRule.additionalLabels`     | Additional labels that can be used so prometheusRules will be discovered by Prometheus                                                                                    | `{}`                                                          |
+| `metrics.prometheusRule.namespace`            | namespace where prometheusRules resource should be created                                                                                                                | the same namespace as postgresql                              |
+| `metrics.prometheusRule.rules`                | [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created, check values for an example.                                            | `[]`                                                          |
+| `metrics.image.registry`                      | PostgreSQL Image registry                                                                                                                                                 | `docker.io`                                                   |
+| `metrics.image.repository`                    | PostgreSQL Image name                                                                                                                                                     | `bitnami/postgres-exporter`                                   |
+| `metrics.image.tag`                           | PostgreSQL Image tag                                                                                                                                                      | `{TAG_NAME}`                                                  |
+| `metrics.image.pullPolicy`                    | PostgreSQL Image pull policy                                                                                                                                              | `IfNotPresent`                                                |
+| `metrics.image.pullSecrets`                   | Specify Image pull secrets                                                                                                                                                | `nil` (does not add image pull secrets to deployed pods)      |
+| `metrics.customMetrics`                       | Additional custom metrics                                                                                                                                                 | `nil`                                                         |
+| `metrics.securityContext.enabled`             | Enable security context for metrics                                                                                                                                       | `false`                                                       |
+| `metrics.securityContext.runAsUser`           | User ID for the container for metrics                                                                                                                                     | `1001`                                                        |
+| `metrics.livenessProbe.initialDelaySeconds`   | Delay before liveness probe is initiated                                                                                                                                  | 30                                                            |
+| `metrics.livenessProbe.periodSeconds`         | How often to perform the probe                                                                                                                                            | 10                                                            |
+| `metrics.livenessProbe.timeoutSeconds`        | When the probe times out                                                                                                                                                  | 5                                                             |
+| `metrics.livenessProbe.failureThreshold`      | Minimum consecutive failures for the probe to be considered failed after having succeeded.                                                                                | 6                                                             |
+| `metrics.livenessProbe.successThreshold`      | Minimum consecutive successes for the probe to be considered successful after having failed                                                                               | 1                                                             |
+| `metrics.readinessProbe.enabled`              | would you like a readinessProbe to be enabled                                                                                                                             | `true`                                                        |
+| `metrics.readinessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                                                                                                  | 5                                                             |
+| `metrics.readinessProbe.periodSeconds`        | How often to perform the probe                                                                                                                                            | 10                                                            |
+| `metrics.readinessProbe.timeoutSeconds`       | When the probe times out                                                                                                                                                  | 5                                                             |
+| `metrics.readinessProbe.failureThreshold`     | Minimum consecutive failures for the probe to be considered failed after having succeeded.                                                                                | 6                                                             |
+| `metrics.readinessProbe.successThreshold`     | Minimum consecutive successes for the probe to be considered successful after having failed                                                                               | 1                                                             |
+| `updateStrategy`                              | Update strategy policy                                                                                                                                                    | `{type: "RollingUpdate"}`                                     |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install my-release \
+  --set postgresqlPassword=secretpassword,postgresqlDatabase=my-database \
+    bitnami/postgresql
+```
+
+The above command sets the PostgreSQL `postgres` account password to `secretpassword`. Additionally it creates a database named `my-database`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install my-release -f values.yaml bitnami/postgresql
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Configuration and installation details
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+### Production configuration and horizontal scaling
+
+This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
+
+- Enable replication:
+```diff
+- replication.enabled: false
++ replication.enabled: true
+```
+
+- Number of slaves replicas:
+```diff
+- replication.slaveReplicas: 1
++ replication.slaveReplicas: 2
+```
+
+- Set synchronous commit mode:
+```diff
+- replication.synchronousCommit: "off"
++ replication.synchronousCommit: "on"
+```
+
+- Number of replicas that will have synchronous replication:
+```diff
+- replication.numSynchronousReplicas: 0
++ replication.numSynchronousReplicas: 1
+```
+
+- Start a prometheus exporter:
+```diff
+- metrics.enabled: false
++ metrics.enabled: true
+```
+
+To horizontally scale this chart, you can use the `--replicas` flag to modify the number of nodes in your PostgreSQL deployment. Also you can use the `values-production.yaml` file or modify the parameters shown above.
+
+### Change PostgreSQL version
+
+To modify the PostgreSQL version used in this chart you can specify a [valid image tag](https://hub.docker.com/r/bitnami/postgresql/tags/) using the `image.tag` parameter. For example, `image.tag=12.0.0`
+
+### postgresql.conf / pg_hba.conf files as configMap
+
+This helm chart also supports to customize the whole configuration file.
+
+Add your custom file to "files/postgresql.conf" in your working directory. This file will be mounted as configMap to the containers and it will be used for configuring the PostgreSQL server.
+
+Alternatively, you can specify PostgreSQL configuration parameters using the `postgresqlConfiguration` parameter as a dict, using camelCase, e.g. {"sharedBuffers": "500MB"}.
+
+In addition to these options, you can also set an external ConfigMap with all the configuration files. This is done by setting the `configurationConfigMap` parameter. Note that this will override the two previous options.
+
+### Allow settings to be loaded from files other than the default `postgresql.conf`
+
+If you don't want to provide the whole PostgreSQL configuration file and only specify certain parameters, you can add your extended `.conf` files to "files/conf.d/" in your working directory.
+Those files will be mounted as configMap to the containers adding/overwriting the default configuration using the `include_dir` directive that allows settings to be loaded from files other than the default `postgresql.conf`.
+
+Alternatively, you can also set an external ConfigMap with all the extra configuration files. This is done by setting the `extendedConfConfigMap` parameter. Note that this will override the previous option.
+
+### Initialize a fresh instance
+
+The [Bitnami PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+
+Alternatively, you can specify custom scripts using the `initdbScripts` parameter as dict.
+
+In addition to these options, you can also set an external ConfigMap with all the initialization scripts. This is done by setting the `initdbScriptsConfigMap` parameter. Note that this will override the two previous options. If your initialization scripts contain sensitive information such as credentials or passwords, you can use the `initdbScriptsSecret` parameter.
+
+The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
+
+### Sidecars
+
+If you need  additional containers to run within the same pod as PostgreSQL (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
+
+```yaml
+# For the PostgreSQL master
+master:
+  sidecars:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+    - name: portname
+     containerPort: 1234
+# For the PostgreSQL replicas
+slave:
+  sidecars:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+    - name: portname
+     containerPort: 1234
+```
+
+### Metrics
+
+The chart optionally can start a metrics exporter for [prometheus](https://prometheus.io). The metrics endpoint (port 9187) is not exposed and it is expected that the metrics are collected from inside the k8s cluster using something similar as the described in the [example Prometheus scrape configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml).
+
+The exporter allows to create custom metrics from additional SQL queries. See the Chart's `values.yaml` for an example and consult the [exporters documentation](https://github.com/wrouesnel/postgres_exporter#adding-new-metrics-via-a-config-file) for more details.
+
+### Use of global variables
+
+In more complex scenarios, we may have the following tree of dependencies
+
+```
+                     +--------------+
+                     |              |
+        +------------+   Chart 1    +-----------+
+        |            |              |           |
+        |            --------+------+           |
+        |                    |                  |
+        |                    |                  |
+        |                    |                  |
+        |                    |                  |
+        v                    v                  v
++-------+------+    +--------+------+  +--------+------+
+|              |    |               |  |               |
+|  PostgreSQL  |    |  Sub-chart 1  |  |  Sub-chart 2  |
+|              |    |               |  |               |
++--------------+    +---------------+  +---------------+
+```
+
+The three charts below depend on the parent chart Chart 1. However, subcharts 1 and 2 may need to connect to PostgreSQL as well. In order to do so, subcharts 1 and 2 need to know the PostgreSQL credentials, so one option for deploying could be deploy Chart 1 with the following parameters:
+
+```
+postgresql.postgresqlPassword=testtest
+subchart1.postgresql.postgresqlPassword=testtest
+subchart2.postgresql.postgresqlPassword=testtest
+postgresql.postgresqlDatabase=db1
+subchart1.postgresql.postgresqlDatabase=db1
+subchart2.postgresql.postgresqlDatabase=db1
+```
+
+If the number of dependent sub-charts increases, installing the chart with parameters can become increasingly difficult. An alternative would be to set the credentials using global variables as follows:
+
+```
+global.postgresql.postgresqlPassword=testtest
+global.postgresql.postgresqlDatabase=db1
+```
+
+This way, the credentials will be available in all of the subcharts.
+
+## Persistence
+
+The [Bitnami PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) image stores the PostgreSQL data and configurations at the `/bitnami/postgresql` path of the container.
+
+Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
+See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
+
+If you already have data in it, you will fail to sync to standby nodes for all commits, details can refer to [code](https://github.com/bitnami/bitnami-docker-postgresql/blob/8725fe1d7d30ebe8d9a16e9175d05f7ad9260c93/9.6/debian-9/rootfs/libpostgresql.sh#L518-L556). If you need to use those data, please covert them to sql and import after `helm install` finished.
+
+## NetworkPolicy
+
+To enable network policy for PostgreSQL, install [a networking plugin that implements the Kubernetes NetworkPolicy spec](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy#before-you-begin), and set `networkPolicy.enabled` to `true`.
+
+For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting the DefaultDeny namespace annotation. Note: this will enforce policy for _all_ pods in the namespace:
+
+```console
+$ kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
+```
+
+With NetworkPolicy enabled, traffic will be limited to just port 5432.
+
+For more precise policy, set `networkPolicy.allowExternal=false`. This will only allow pods with the generated client label to connect to PostgreSQL.
+This label will be displayed in the output of a successful install.
+
+## Differences between Bitnami PostgreSQL image and [Docker Official](https://hub.docker.com/_/postgres) image
+
+- The Docker Official PostgreSQL image does not support replication. If you pass any replication environment variable, this would be ignored. The only environment variables supported by the Docker Official image are POSTGRES_USER, POSTGRES_DB, POSTGRES_PASSWORD, POSTGRES_INITDB_ARGS, POSTGRES_INITDB_WALDIR and PGDATA. All the remaining environment variables are specific to the Bitnami PostgreSQL image.
+- The Bitnami PostgreSQL image is non-root by default. This requires that you run the pod with `securityContext` and updates the permissions of the volume with an `initContainer`. A key benefit of this configuration is that the pod follows security best practices and is prepared to run on Kubernetes distributions with hard security constraints like OpenShift.
+- For OpenShift, one may either define the runAsUser and fsGroup accordingly, or try this more dynamic option: volumePermissions.securityContext.runAsUser="auto",securityContext.enabled=false,shmVolume.chmod.enabled=false
+
+### Deploy chart using Docker Official PostgreSQL Image
+
+From chart version 4.0.0, it is possible to use this chart with the Docker Official PostgreSQL image.
+Besides specifying the new Docker repository and tag, it is important to modify the PostgreSQL data directory and volume mount point. Basically, the PostgreSQL data dir cannot be the mount point directly, it has to be a subdirectory.
+
+```
+helm install postgres \
+             --set image.repository=postgres \
+             --set image.tag=10.6 \
+             --set postgresqlDataDir=/data/pgdata \
+             --set persistence.mountPath=/data/ \
+             bitnami/postgresql
+```
+
+## Upgrade
+
+It's necessary to specify the existing passwords while performing an upgrade to ensure the secrets are not updated with invalid randomly generated passwords. Remember to specify the existing values of the `postgresqlPassword` and `replication.password` parameters when upgrading the chart:
+
+```bash
+$ helm upgrade my-release stable/postgresql \
+    --set postgresqlPassword=[POSTGRESQL_PASSWORD] \
+    --set replication.password=[REPLICATION_PASSWORD]
+```
+
+> Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPLICATION_PASSWORD]_ with the values obtained from instructions in the installation notes.
+
+## 8.0.0
+
+Prefixes the port names with their protocols to comply with Istio conventions.
+
+If you depend on the port names in your setup, make sure to update them to reflect this change.
+
+## 7.1.0
+
+Adds support for LDAP configuration.
+
+## 7.0.0
+
+Helm performs a lookup for the object based on its group (apps), version (v1), and kind (Deployment). Also known as its GroupVersionKind, or GVK. Changing the GVK is considered a compatibility breaker from Kubernetes' point of view, so you cannot "upgrade" those objects to the new GVK in-place. Earlier versions of Helm 3 did not perform the lookup correctly which has since been fixed to match the spec.
+
+In https://github.com/helm/charts/pull/17281 the `apiVersion` of the statefulset resources was updated to `apps/v1` in tune with the api's deprecated, resulting in compatibility breakage.
+
+This major version bump signifies this change.
+
+## 6.5.7
+
+In this version, the chart will use PostgreSQL with the Postgis extension included. The version used with Postgresql version 10, 11 and 12 is Postgis 2.5. It has been compiled with the following dependencies:
+
+ - protobuf
+ - protobuf-c
+ - json-c
+ - geos
+ - proj
+
+## 5.0.0
+
+In this version, the **chart is using PostgreSQL 11 instead of PostgreSQL 10**. You can find the main difference and notable changes in the following links: [https://www.postgresql.org/about/news/1894/](https://www.postgresql.org/about/news/1894/) and [https://www.postgresql.org/about/featurematrix/](https://www.postgresql.org/about/featurematrix/).
+
+For major releases of PostgreSQL, the internal data storage format is subject to change, thus complicating upgrades, you can see some errors like the following one in the logs:
+
+```bash
+Welcome to the Bitnami postgresql container
+Subscribe to project updates by watching https://github.com/bitnami/bitnami-docker-postgresql
+Submit issues and feature requests at https://github.com/bitnami/bitnami-docker-postgresql/issues
+Send us your feedback at containers@bitnami.com
+
+INFO  ==> ** Starting PostgreSQL setup **
+NFO  ==> Validating settings in POSTGRESQL_* env vars..
+INFO  ==> Initializing PostgreSQL database...
+INFO  ==> postgresql.conf file not detected. Generating it...
+INFO  ==> pg_hba.conf file not detected. Generating it...
+INFO  ==> Deploying PostgreSQL with persisted data...
+INFO  ==> Configuring replication parameters
+INFO  ==> Loading custom scripts...
+INFO  ==> Enabling remote connections
+INFO  ==> Stopping PostgreSQL...
+INFO  ==> ** PostgreSQL setup finished! **
+
+INFO  ==> ** Starting PostgreSQL **
+  [1] FATAL:  database files are incompatible with server
+  [1] DETAIL:  The data directory was initialized by PostgreSQL version 10, which is not compatible with this version 11.3.
+```
+In this case, you should migrate the data from the old chart to the new one following an approach similar to that described in [this section](https://www.postgresql.org/docs/current/upgrading.html#UPGRADING-VIA-PGDUMPALL) from the official documentation. Basically, create a database dump in the old chart, move and restore it in the new one.
+
+### 4.0.0
+
+This chart will use by default the Bitnami PostgreSQL container starting from version `10.7.0-r68`. This version moves the initialization logic from node.js to bash. This new version of the chart requires setting the `POSTGRES_PASSWORD` in the slaves as well, in order to properly configure the `pg_hba.conf` file. Users from previous versions of the chart are advised to upgrade immediately.
+
+IMPORTANT: If you do not want to upgrade the chart version then make sure you use the `10.7.0-r68` version of the container. Otherwise, you will get this error
+
+```
+The POSTGRESQL_PASSWORD environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development
+```
+
+### 3.0.0
+
+This releases make it possible to specify different nodeSelector, affinity and tolerations for master and slave pods.
+It also fixes an issue with `postgresql.master.fullname` helper template not obeying fullnameOverride.
+
+#### Breaking changes
+
+- `affinty` has been renamed to `master.affinity` and `slave.affinity`.
+- `tolerations` has been renamed to `master.tolerations` and `slave.tolerations`.
+- `nodeSelector` has been renamed to `master.nodeSelector` and `slave.nodeSelector`.
+
+### 2.0.0
+
+In order to upgrade from the `0.X.X` branch to `1.X.X`, you should follow the below steps:
+
+ - Obtain the service name (`SERVICE_NAME`) and password (`OLD_PASSWORD`) of the existing postgresql chart. You can find the instructions to obtain the password in the NOTES.txt, the service name can be obtained by running
+
+ ```console
+$ kubectl get svc
+ ```
+
+- Install (not upgrade) the new version
+
+```console
+$ helm repo update
+$ helm install my-release bitnami/postgresql
+```
+
+- Connect to the new pod (you can obtain the name by running `kubectl get pods`):
+
+```console
+$ kubectl exec -it NAME bash
+```
+
+- Once logged in, create a dump file from the previous database using `pg_dump`, for that we should connect to the previous postgresql chart:
+
+```console
+$ pg_dump -h SERVICE_NAME -U postgres DATABASE_NAME > /tmp/backup.sql
+```
+
+After run above command you should be prompted for a password, this password is the previous chart password (`OLD_PASSWORD`).
+This operation could take some time depending on the database size.
+
+- Once you have the backup file, you can restore it with a command like the one below:
+
+```console
+$ psql -U postgres DATABASE_NAME < /tmp/backup.sql
+```
+
+In this case, you are accessing to the local postgresql, so the password should be the new one (you can find it in NOTES.txt).
+
+If you want to restore the database and the database schema does not exist, it is necessary to first follow the steps described below.
+
+```console
+$ psql -U postgres
+postgres=# drop database DATABASE_NAME;
+postgres=# create database DATABASE_NAME;
+postgres=# create user USER_NAME;
+postgres=# alter role USER_NAME with password 'BITNAMI_USER_PASSWORD';
+postgres=# grant all privileges on database DATABASE_NAME to USER_NAME;
+postgres=# alter database DATABASE_NAME owner to USER_NAME;
+```

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/ci/default-values.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/ci/shmvolume-disabled-values.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/ci/shmvolume-disabled-values.yaml
@@ -1,0 +1,2 @@
+shmVolume:
+  enabled: false

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/files/README.md
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/files/README.md
@@ -1,0 +1,1 @@
+Copy here your postgresql.conf and/or pg_hba.conf files to use it as a config map.

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/files/conf.d/README.md
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/files/conf.d/README.md
@@ -1,0 +1,4 @@
+If you don't want to provide the whole configuration file and only specify certain parameters, you can copy here your extended `.conf` files.
+These files will be injected as a config maps and add/overwrite the default configuration using the `include_dir` directive that allows settings to be loaded from files other than the default `postgresql.conf`.
+
+More info in the [bitnami-docker-postgresql README](https://github.com/bitnami/bitnami-docker-postgresql#configuration-file).

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/files/docker-entrypoint-initdb.d/README.md
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/files/docker-entrypoint-initdb.d/README.md
@@ -1,0 +1,3 @@
+You can copy here your custom `.sh`, `.sql` or `.sql.gz` file so they are executed during the first boot of the image.
+
+More info in the [bitnami-docker-postgresql](https://github.com/bitnami/bitnami-docker-postgresql#initializing-a-new-instance) repository.

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/NOTES.txt
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/NOTES.txt
@@ -1,0 +1,60 @@
+** Please be patient while the chart is being deployed **
+
+PostgreSQL can be accessed via port {{ template "postgresql.port" . }} on the following DNS name from within your cluster:
+
+    {{ template "postgresql.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local - Read/Write connection
+{{- if .Values.replication.enabled }}
+    {{ template "postgresql.fullname" . }}-read.{{ .Release.Namespace }}.svc.cluster.local - Read only connection
+{{- end }}
+
+{{- if and .Values.postgresqlPostgresPassword (not (eq .Values.postgresqlUsername "postgres")) }}
+
+To get the password for "postgres" run:
+
+    export POSTGRES_ADMIN_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "postgresql.secretName" . }} -o jsonpath="{.data.postgresql-postgres-password}" | base64 --decode)
+{{- end }}
+
+To get the password for "{{ template "postgresql.username" . }}" run:
+
+    export POSTGRES_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "postgresql.secretName" . }} -o jsonpath="{.data.postgresql-password}" | base64 --decode)
+
+To connect to your database run the following command:
+
+    kubectl run {{ template "postgresql.fullname" . }}-client --rm --tty -i --restart='Never' --namespace {{ .Release.Namespace }} --image {{ template "postgresql.image" . }} --env="PGPASSWORD=$POSTGRES_PASSWORD" {{- if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
+   --labels="{{ template "postgresql.fullname" . }}-client=true" {{- end }} --command -- psql --host {{ template "postgresql.fullname" . }} -U {{ .Values.postgresqlUsername }} -d {{- if .Values.postgresqlDatabase }} {{ .Values.postgresqlDatabase }}{{- else }} postgres{{- end }} -p {{ template "postgresql.port" . }}
+
+{{ if and (.Values.networkPolicy.enabled) (not .Values.networkPolicy.allowExternal) }}
+Note: Since NetworkPolicy is enabled, only pods with label {{ template "postgresql.fullname" . }}-client=true" will be able to connect to this PostgreSQL cluster.
+{{- end }}
+
+To connect to your database from outside the cluster execute the following commands:
+
+{{- if contains "NodePort" .Values.service.type }}
+
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "postgresql.fullname" . }})
+    {{ if (include "postgresql.password" . )  }}PGPASSWORD="$POSTGRES_PASSWORD" {{ end }}psql --host $NODE_IP --port $NODE_PORT -U {{ .Values.postgresqlUsername }} -d {{- if .Values.postgresqlDatabase }} {{ .Values.postgresqlDatabase }}{{- else }} postgres{{- end }}
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "postgresql.fullname" . }}'
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "postgresql.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+    {{ if (include "postgresql.password" . ) }}PGPASSWORD="$POSTGRES_PASSWORD" {{ end }}psql --host $SERVICE_IP --port {{ template "postgresql.port" . }} -U {{ .Values.postgresqlUsername }} -d {{- if .Values.postgresqlDatabase }} {{ .Values.postgresqlDatabase }}{{- else }} postgres{{- end }}
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "postgresql.fullname" . }} {{ template "postgresql.port" . }}:{{ template "postgresql.port" . }} &
+    {{ if (include "postgresql.password" . ) }}PGPASSWORD="$POSTGRES_PASSWORD" {{ end }}psql --host 127.0.0.1 -U {{ .Values.postgresqlUsername }} -d {{- if .Values.postgresqlDatabase }} {{ .Values.postgresqlDatabase }}{{- else }} postgres{{- end }} -p {{ template "postgresql.port" . }}
+
+{{- end }}
+
+{{- include "postgresql.validateValues" . -}}
+
+{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+
+WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/_helpers.tpl
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/_helpers.tpl
@@ -1,0 +1,420 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "postgresql.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "postgresql.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "postgresql.master.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $fullname := default (printf "%s-%s" .Release.Name $name) .Values.fullnameOverride -}}
+{{- if .Values.replication.enabled -}}
+{{- printf "%s-%s" $fullname "master" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" $fullname | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "postgresql.networkPolicy.apiVersion" -}}
+{{- if semverCompare ">=1.4-0, <1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+"extensions/v1beta1"
+{{- else if semverCompare "^1.7-0" .Capabilities.KubeVersion.GitVersion -}}
+"networking.k8s.io/v1"
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "postgresql.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the proper PostgreSQL image name
+*/}}
+{{- define "postgresql.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return PostgreSQL postgres user password
+*/}}
+{{- define "postgresql.postgres.password" -}}
+{{- if .Values.global.postgresql.postgresqlPostgresPassword }}
+    {{- .Values.global.postgresql.postgresqlPostgresPassword -}}
+{{- else if .Values.postgresqlPostgresPassword -}}
+    {{- .Values.postgresqlPostgresPassword -}}
+{{- else -}}
+    {{- randAlphaNum 10 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return PostgreSQL password
+*/}}
+{{- define "postgresql.password" -}}
+{{- if .Values.global.postgresql.postgresqlPassword }}
+    {{- .Values.global.postgresql.postgresqlPassword -}}
+{{- else if .Values.postgresqlPassword -}}
+    {{- .Values.postgresqlPassword -}}
+{{- else -}}
+    {{- randAlphaNum 10 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return PostgreSQL replication password
+*/}}
+{{- define "postgresql.replication.password" -}}
+{{- if .Values.global.postgresql.replicationPassword }}
+    {{- .Values.global.postgresql.replicationPassword -}}
+{{- else if .Values.replication.password -}}
+    {{- .Values.replication.password -}}
+{{- else -}}
+    {{- randAlphaNum 10 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return PostgreSQL username
+*/}}
+{{- define "postgresql.username" -}}
+{{- if .Values.global.postgresql.postgresqlUsername }}
+    {{- .Values.global.postgresql.postgresqlUsername -}}
+{{- else -}}
+    {{- .Values.postgresqlUsername -}}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Return PostgreSQL replication username
+*/}}
+{{- define "postgresql.replication.username" -}}
+{{- if .Values.global.postgresql.replicationUser }}
+    {{- .Values.global.postgresql.replicationUser -}}
+{{- else -}}
+    {{- .Values.replication.user -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return PostgreSQL port
+*/}}
+{{- define "postgresql.port" -}}
+{{- if .Values.global.postgresql.servicePort }}
+    {{- .Values.global.postgresql.servicePort -}}
+{{- else -}}
+    {{- .Values.service.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return PostgreSQL created database
+*/}}
+{{- define "postgresql.database" -}}
+{{- if .Values.global.postgresql.postgresqlDatabase }}
+    {{- .Values.global.postgresql.postgresqlDatabase -}}
+{{- else if .Values.postgresqlDatabase -}}
+    {{- .Values.postgresqlDatabase -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper image name to change the volume permissions
+*/}}
+{{- define "postgresql.volumePermissions.image" -}}
+{{- $registryName := .Values.volumePermissions.image.registry -}}
+{{- $repositoryName := .Values.volumePermissions.image.repository -}}
+{{- $tag := .Values.volumePermissions.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper PostgreSQL metrics image name
+*/}}
+{{- define "postgresql.metrics.image" -}}
+{{- $registryName :=  default "docker.io" .Values.metrics.image.registry -}}
+{{- $repositoryName := .Values.metrics.image.repository -}}
+{{- $tag := default "latest" .Values.metrics.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the password secret.
+*/}}
+{{- define "postgresql.secretName" -}}
+{{- if .Values.global.postgresql.existingSecret }}
+    {{- printf "%s" .Values.global.postgresql.existingSecret -}}
+{{- else if .Values.existingSecret -}}
+    {{- printf "%s" .Values.existingSecret -}}
+{{- else -}}
+    {{- printf "%s" (include "postgresql.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a secret object should be created
+*/}}
+{{- define "postgresql.createSecret" -}}
+{{- if .Values.global.postgresql.existingSecret }}
+{{- else if .Values.existingSecret -}}
+{{- else -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the configuration ConfigMap name.
+*/}}
+{{- define "postgresql.configurationCM" -}}
+{{- if .Values.configurationConfigMap -}}
+{{- printf "%s" (tpl .Values.configurationConfigMap $) -}}
+{{- else -}}
+{{- printf "%s-configuration" (include "postgresql.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the extended configuration ConfigMap name.
+*/}}
+{{- define "postgresql.extendedConfigurationCM" -}}
+{{- if .Values.extendedConfConfigMap -}}
+{{- printf "%s" (tpl .Values.extendedConfConfigMap $) -}}
+{{- else -}}
+{{- printf "%s-extended-configuration" (include "postgresql.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the initialization scripts ConfigMap name.
+*/}}
+{{- define "postgresql.initdbScriptsCM" -}}
+{{- if .Values.initdbScriptsConfigMap -}}
+{{- printf "%s" (tpl .Values.initdbScriptsConfigMap $) -}}
+{{- else -}}
+{{- printf "%s-init-scripts" (include "postgresql.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the initialization scripts Secret name.
+*/}}
+{{- define "postgresql.initdbScriptsSecret" -}}
+{{- printf "%s" (tpl .Values.initdbScriptsSecret $) -}}
+{{- end -}}
+
+{{/*
+Get the metrics ConfigMap name.
+*/}}
+{{- define "postgresql.metricsCM" -}}
+{{- printf "%s-metrics" (include "postgresql.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "postgresql.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets .Values.volumePermissions.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.metrics.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.volumePermissions.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets .Values.volumePermissions.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.metrics.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.volumePermissions.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the readiness probe command
+*/}}
+{{- define "postgresql.readinessProbeCommand" -}}
+- |
+{{- if (include "postgresql.database" .) }}
+  exec pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+{{- else }}
+  exec pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+{{- end }}
+{{- if contains "bitnami/" .Values.image.repository }}
+  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return  the proper Storage Class
+*/}}
+{{- define "postgresql.storageClass" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+*/}}
+{{- if .Values.global -}}
+    {{- if .Values.global.storageClass -}}
+        {{- if (eq "-" .Values.global.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+        {{- end -}}
+    {{- else -}}
+        {{- if .Values.persistence.storageClass -}}
+              {{- if (eq "-" .Values.persistence.storageClass) -}}
+                  {{- printf "storageClassName: \"\"" -}}
+              {{- else }}
+                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
+              {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- else -}}
+    {{- if .Values.persistence.storageClass -}}
+        {{- if (eq "-" .Values.persistence.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "postgresql.tplValue" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "postgresql.tplValue" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for statefulset.
+*/}}
+{{- define "postgresql.statefulset.apiVersion" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- print "apps/v1beta2" -}}
+{{- else -}}
+{{- print "apps/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "postgresql.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "postgresql.validateValues.ldapConfigurationMethod" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{- printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of Postgresql - If ldap.url is used then you don't need the other settings for ldap
+*/}}
+{{- define "postgresql.validateValues.ldapConfigurationMethod" -}}
+{{- if and .Values.ldap.enabled (and (not (empty .Values.ldap.url)) (not (empty .Values.ldap.server))) }}
+postgresql: ldap.url, ldap.server
+    You cannot set both `ldap.url` and `ldap.server` at the same time.
+    Please provide a unique way to configure LDAP.
+    More info at https://www.postgresql.org/docs/current/auth-ldap.html
+{{- end -}}
+{{- end -}}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/configmap.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/configmap.yaml
@@ -1,0 +1,26 @@
+{{ if and (or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration) (not .Values.configurationConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "postgresql.fullname" . }}-configuration
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+data:
+{{- if (.Files.Glob "files/postgresql.conf") }}
+{{ (.Files.Glob "files/postgresql.conf").AsConfig | indent 2 }}
+{{- else if .Values.postgresqlConfiguration }}
+  postgresql.conf: |
+{{- range $key, $value := default dict .Values.postgresqlConfiguration }}
+    {{ $key | snakecase }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- if (.Files.Glob "files/pg_hba.conf") }}
+{{ (.Files.Glob "files/pg_hba.conf").AsConfig | indent 2 }}
+{{- else if .Values.pgHbaConfiguration }}
+  pg_hba.conf: |
+{{ .Values.pgHbaConfiguration | indent 4 }}
+{{- end }}
+{{ end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/extended-config-configmap.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/extended-config-configmap.yaml
@@ -1,0 +1,21 @@
+{{- if and (or (.Files.Glob "files/conf.d/*.conf") .Values.postgresqlExtendedConf) (not .Values.extendedConfConfigMap)}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "postgresql.fullname" . }}-extended-configuration
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+data:
+{{- with .Files.Glob "files/conf.d/*.conf" }}
+{{ .AsConfig | indent 2 }}
+{{- end }}
+{{ with .Values.postgresqlExtendedConf }}
+  override.conf: |
+{{- range $key, $value := . }}
+    {{ $key | snakecase }}={{ $value }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/initialization-configmap.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/initialization-configmap.yaml
@@ -1,0 +1,24 @@
+{{- if and (or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScripts) (not .Values.initdbScriptsConfigMap) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "postgresql.fullname" . }}-init-scripts
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Files.Glob "files/docker-entrypoint-initdb.d/*.sql.gz" }}
+binaryData:
+{{- range $path, $bytes := . }}
+  {{ base $path }}: {{ $.Files.Get $path | b64enc | quote }}
+{{- end }}
+{{- end }}
+data:
+{{- with .Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql}" }}
+{{ .AsConfig | indent 2 }}
+{{- end }}
+{{- with .Values.initdbScripts }}
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/metrics-configmap.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/metrics-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.metrics.enabled .Values.metrics.customMetrics }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "postgresql.metricsCM" . }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+data:
+  custom-metrics.yaml: {{ toYaml .Values.metrics.customMetrics | quote }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/metrics-svc.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/metrics-svc.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "postgresql.fullname" . }}-metrics
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  annotations:
+{{ toYaml .Values.metrics.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  {{- if and (eq .Values.metrics.service.type "LoadBalancer") .Values.metrics.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: http-metrics
+      port: 9187
+      targetPort: http-metrics
+  selector:
+    app: {{ template "postgresql.name" . }}
+    release: {{ .Release.Name }}
+    role: master
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/networkpolicy.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/networkpolicy.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ template "postgresql.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "postgresql.fullname" . }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "postgresql.name" . }}
+      release: {{ .Release.Name | quote }}
+  ingress:
+    # Allow inbound connections
+    - ports:
+        - port: {{ template "postgresql.port" . }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "postgresql.fullname" . }}-client: "true"
+          {{- if .Values.networkPolicy.explicitNamespacesSelector }}
+          namespaceSelector:
+{{ toYaml .Values.networkPolicy.explicitNamespacesSelector | indent 12 }}
+          {{- end }}
+        - podSelector:
+            matchLabels:
+              app: {{ template "postgresql.name" . }}
+              release: {{ .Release.Name | quote }}
+              role: slave
+      {{- end }}
+    # Allow prometheus scrapes
+    - ports:
+        - port: 9187
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/prometheusrule.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "postgresql.fullname" . }}
+{{- with .Values.metrics.prometheusRule.namespace }}
+  namespace: {{ . }}
+{{- end }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Values.metrics.prometheusRule.additionalLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.metrics.prometheusRule.rules }}
+  groups:
+    - name: {{ template "postgresql.name" $ }}
+      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/secrets.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/secrets.yaml
@@ -1,0 +1,23 @@
+{{- if (include "postgresql.createSecret" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "postgresql.fullname" . }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+type: Opaque
+data:
+  {{- if and .Values.postgresqlPostgresPassword (not (eq .Values.postgresqlUsername "postgres")) }}
+  postgresql-postgres-password: {{ include "postgresql.postgres.password" . | b64enc | quote }}
+  {{- end }}
+  postgresql-password: {{ include "postgresql.password" . | b64enc | quote }}
+  {{- if .Values.replication.enabled }}
+  postgresql-replication-password: {{ include "postgresql.replication.password" . | b64enc | quote }}
+  {{- end }}
+  {{- if (and .Values.ldap.enabled .Values.ldap.bind_password)}}
+  postgresql-ldap-password: {{ .Values.ldap.bind_password | b64enc | quote }}
+  {{- end }}
+{{- end -}}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/serviceaccount.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if and (.Values.serviceAccount.enabled) (not .Values.serviceAccount.name) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  name: {{ template "postgresql.fullname" . }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/servicemonitor.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "postgresql.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: http-metrics
+      {{- if .Values.metrics.serviceMonitor.interval }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "postgresql.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/statefulset-slaves.yaml
@@ -1,0 +1,299 @@
+{{- if .Values.replication.enabled }}
+apiVersion: {{ template "postgresql.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: "{{ template "postgresql.fullname" . }}-slave"
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Values.slave.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.slave.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  serviceName: {{ template "postgresql.fullname" . }}-headless
+  replicas: {{ .Values.replication.slaveReplicas }}
+  selector:
+    matchLabels:
+      app: {{ template "postgresql.name" . }}
+      release: {{ .Release.Name | quote }}
+      role: slave
+  template:
+    metadata:
+      name: {{ template "postgresql.fullname" . }}
+      labels:
+        app: {{ template "postgresql.name" . }}
+        chart: {{ template "postgresql.chart" . }}
+        release: {{ .Release.Name | quote }}
+        heritage: {{ .Release.Service | quote }}
+        role: slave
+{{- with .Values.slave.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.slave.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+{{- include "postgresql.imagePullSecrets" . | indent 6 }}
+      {{- if .Values.slave.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.slave.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.slave.affinity }}
+      affinity:
+{{ toYaml .Values.slave.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.slave.tolerations }}
+      tolerations:
+{{ toYaml .Values.slave.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ default (include "postgresql.fullname" . ) .Values.serviceAccount.name}}
+      {{- end }}
+      {{- if or .Values.slave.extraInitContainers (and .Values.volumePermissions.enabled (or .Values.persistence.enabled (and .Values.shmVolume.enabled .Values.shmVolume.chmod.enabled))) }}
+      initContainers:
+      {{- if and .Values.volumePermissions.enabled (or .Values.persistence.enabled (and .Values.shmVolume.enabled .Values.shmVolume.chmod.enabled)) }}
+        - name: init-chmod-data
+          image: {{ template "postgresql.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -cx
+            - |
+              {{ if .Values.persistence.enabled }}
+              mkdir -p {{ .Values.persistence.mountPath }}/data
+              chmod 700 {{ .Values.persistence.mountPath }}/data
+              find {{ .Values.persistence.mountPath }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
+              {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
+                xargs chown -R `id -u`:`id -G | cut -d " " -f2`
+              {{- else }}
+                xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
+              {{- end }}
+              {{- end }}
+              {{- if and .Values.shmVolume.enabled .Values.shmVolume.chmod.enabled }}
+              chmod -R 777 /dev/shm
+              {{- end }}
+          {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
+          securityContext:
+          {{- else }}
+          securityContext:
+            runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
+          {{- end }}
+          volumeMounts:
+            {{ if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              subPath: {{ .Values.persistence.subPath }}
+            {{- end }}
+            {{- if .Values.shmVolume.enabled }}
+            - name: dshm
+              mountPath: /dev/shm
+            {{- end }}
+      {{- end }}
+      {{- if .Values.slave.extraInitContainers }}
+{{ tpl .Values.slave.extraInitContainers . | indent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.slave.priorityClassName }}
+      priorityClassName: {{ .Values.slave.priorityClassName }}
+      {{- end }}
+      containers:
+        - name: {{ template "postgresql.fullname" . }}
+          image: {{ template "postgresql.image" . }}
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+          {{- end }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "{{ .Values.persistence.mountPath }}"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "{{ template "postgresql.port" . }}"
+            {{- if .Values.persistence.mountPath }}
+            - name: PGDATA
+              value: {{ .Values.postgresqlDataDir | quote }}
+            {{- end }}
+            - name: POSTGRES_REPLICATION_MODE
+              value: "slave"
+            - name: POSTGRES_REPLICATION_USER
+              value: {{ include "postgresql.replication.username" . | quote }}
+            {{- if .Values.usePasswordFile }}
+            - name: POSTGRES_REPLICATION_PASSWORD_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-replication-password"
+            {{- else }}
+            - name: POSTGRES_REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-replication-password
+            {{- end }}
+            - name: POSTGRES_CLUSTER_APP_NAME
+              value: {{ .Values.replication.applicationName }}
+            - name: POSTGRES_MASTER_HOST
+              value: {{ template "postgresql.fullname" . }}
+            - name: POSTGRES_MASTER_PORT_NUMBER
+              value: {{ include "postgresql.port" . | quote }}
+            {{- if and .Values.postgresqlPostgresPassword (not (eq .Values.postgresqlUsername "postgres")) }}
+            {{- if .Values.usePasswordFile }}
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-postgres-password"
+            {{- else }}
+            - name: POSTGRES_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-postgres-password
+            {{- end }}
+            {{- end }}
+            {{- if .Values.usePasswordFile }}
+            - name: POSTGRES_PASSWORD_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-password"
+            {{- else }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-password
+            {{- end }}
+          ports:
+            - name: tcp-postgresql
+              containerPort: {{ template "postgresql.port" . }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                {{- if (include "postgresql.database" .) }}
+                - exec pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+                {{- else }}
+                - exec pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+                {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                {{- include "postgresql.readinessProbeCommand" . | nindent 16 }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.usePasswordFile }}
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            {{- end }}
+            {{- if .Values.shmVolume.enabled }}
+            - name: dshm
+              mountPath: /dev/shm
+            {{- end }}
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              subPath: {{ .Values.persistence.subPath }}
+            {{ end }}
+            {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresqlExtendedConf .Values.extendedConfConfigMap }}
+            - name: postgresql-extended-config
+              mountPath: /bitnami/postgresql/conf/conf.d/
+            {{- end }}
+            {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap }}
+            - name: postgresql-config
+              mountPath: /bitnami/postgresql/conf
+            {{- end }}
+            {{- if .Values.slave.extraVolumeMounts }}
+            {{- toYaml .Values.slave.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+{{- if .Values.slave.sidecars }}
+{{- include "postgresql.tplValue" ( dict "value" .Values.slave.sidecars "context" $ ) | nindent 8 }}
+{{- end }}
+      volumes:
+        {{- if .Values.usePasswordFile }}
+        - name: postgresql-password
+          secret:
+            secretName: {{ template "postgresql.secretName" . }}
+        {{- end }}
+        {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap}}
+        - name: postgresql-config
+          configMap:
+            name: {{ template "postgresql.configurationCM" . }}
+        {{- end }}
+        {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresqlExtendedConf .Values.extendedConfConfigMap }}
+        - name: postgresql-extended-config
+          configMap:
+            name: {{ template "postgresql.extendedConfigurationCM" . }}
+        {{- end }}
+        {{- if .Values.shmVolume.enabled }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+        {{- end }}
+        {{- if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.slave.extraVolumes }}
+        {{- toYaml .Values.slave.extraVolumes | nindent 8 }}
+        {{- end }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+    {{- if (eq "Recreate" .Values.updateStrategy.type) }}
+    rollingUpdate: null
+    {{- end }}
+{{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      {{- with .Values.persistence.annotations }}
+        annotations:
+        {{- range $key, $value := . }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        {{ include "postgresql.storageClass" . }}
+{{- end }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/statefulset.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/statefulset.yaml
@@ -1,0 +1,458 @@
+apiVersion: {{ template "postgresql.statefulset.apiVersion" . }}
+kind: StatefulSet
+metadata:
+  name: {{ template "postgresql.master.fullname" . }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Values.master.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.master.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  serviceName: {{ template "postgresql.fullname" . }}-headless
+  replicas: 1
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+    {{- if (eq "Recreate" .Values.updateStrategy.type) }}
+    rollingUpdate: null
+    {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "postgresql.name" . }}
+      release: {{ .Release.Name | quote }}
+      role: master
+  template:
+    metadata:
+      name: {{ template "postgresql.fullname" . }}
+      labels:
+        app: {{ template "postgresql.name" . }}
+        chart: {{ template "postgresql.chart" . }}
+        release: {{ .Release.Name | quote }}
+        heritage: {{ .Release.Service | quote }}
+        role: master
+{{- with .Values.master.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.master.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+{{- include "postgresql.imagePullSecrets" . | indent 6 }}
+      {{- if .Values.master.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.master.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.master.affinity }}
+      affinity:
+{{ toYaml .Values.master.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.master.tolerations }}
+      tolerations:
+{{ toYaml .Values.master.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ default (include "postgresql.fullname" . ) .Values.serviceAccount.name }}
+      {{- end }}
+      {{- if or .Values.master.extraInitContainers (and .Values.volumePermissions.enabled (or .Values.persistence.enabled (and .Values.shmVolume.enabled .Values.shmVolume.chmod.enabled))) }}
+      initContainers:
+      {{- if and .Values.volumePermissions.enabled (or .Values.persistence.enabled (and .Values.shmVolume.enabled .Values.shmVolume.chmod.enabled)) }}
+        - name: init-chmod-data
+          image: {{ template "postgresql.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -cx
+            - |
+              {{ if .Values.persistence.enabled }}
+              mkdir -p {{ .Values.persistence.mountPath }}/data
+              chmod 700 {{ .Values.persistence.mountPath }}/data
+              find {{ .Values.persistence.mountPath }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
+              {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
+                xargs chown -R `id -u`:`id -G | cut -d " " -f2`
+              {{- else }}
+                xargs chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}
+              {{- end }}
+              {{- end }}
+              {{- if and .Values.shmVolume.enabled .Values.shmVolume.chmod.enabled }}
+              chmod -R 777 /dev/shm
+              {{- end }}
+          {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
+          securityContext:
+          {{- else }}
+          securityContext:
+            runAsUser: {{ .Values.volumePermissions.securityContext.runAsUser }}
+          {{- end }}
+          volumeMounts:
+            {{ if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              subPath: {{ .Values.persistence.subPath }}
+            {{- end }}
+            {{- if .Values.shmVolume.enabled }}
+            - name: dshm
+              mountPath: /dev/shm
+            {{- end }}
+      {{- end }}
+      {{- if .Values.master.extraInitContainers }}
+{{ tpl .Values.master.extraInitContainers . | indent 8 }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.master.priorityClassName }}
+      priorityClassName: {{ .Values.master.priorityClassName }}
+      {{- end }}
+      containers:
+        - name: {{ template "postgresql.fullname" . }}
+          image: {{ template "postgresql.image" . }}
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+          {{- end }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "{{ template "postgresql.port" . }}"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "{{ .Values.persistence.mountPath }}"
+            {{- if .Values.postgresqlInitdbArgs }}
+            - name: POSTGRES_INITDB_ARGS
+              value: {{ .Values.postgresqlInitdbArgs | quote }}
+            {{- end }}
+            {{- if .Values.postgresqlInitdbWalDir }}
+            - name: POSTGRES_INITDB_WALDIR
+              value: {{ .Values.postgresqlInitdbWalDir | quote }}
+            {{- end }}
+            {{- if .Values.initdbUser }}
+            - name: POSTGRESQL_INITSCRIPTS_USERNAME
+              value: {{ .Values.initdbUser }}
+            {{- end }}
+            {{- if .Values.initdbPassword }}
+            - name: POSTGRESQL_INITSCRIPTS_PASSWORD
+              value: .Values.initdbPassword
+            {{- end }}
+            {{- if .Values.persistence.mountPath }}
+            - name: PGDATA
+              value: {{ .Values.postgresqlDataDir | quote }}
+            {{- end }}
+            {{- if .Values.replication.enabled }}
+            - name: POSTGRES_REPLICATION_MODE
+              value: "master"
+            - name: POSTGRES_REPLICATION_USER
+              value: {{ include "postgresql.replication.username" . | quote }}
+            {{- if .Values.usePasswordFile }}
+            - name: POSTGRES_REPLICATION_PASSWORD_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-replication-password"
+            {{- else }}
+            - name: POSTGRES_REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-replication-password
+            {{- end }}
+            {{- if not (eq .Values.replication.synchronousCommit "off")}}
+            - name: POSTGRES_SYNCHRONOUS_COMMIT_MODE
+              value: {{ .Values.replication.synchronousCommit | quote }}
+            - name: POSTGRES_NUM_SYNCHRONOUS_REPLICAS
+              value: {{ .Values.replication.numSynchronousReplicas | quote }}
+            {{- end }}
+            - name: POSTGRES_CLUSTER_APP_NAME
+              value: {{ .Values.replication.applicationName }}
+            {{- end }}
+            {{- if and .Values.postgresqlPostgresPassword (not (eq .Values.postgresqlUsername "postgres")) }}
+            {{- if .Values.usePasswordFile }}
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-postgres-password"
+            {{- else }}
+            - name: POSTGRES_POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-postgres-password
+            {{- end }}
+            {{- end }}
+            - name: POSTGRES_USER
+              value: {{ include "postgresql.username" . | quote }}
+            {{- if .Values.usePasswordFile }}
+            - name: POSTGRES_PASSWORD_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-password"
+            {{- else }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-password
+            {{- end }}
+            {{- if (include "postgresql.database" .) }}
+            - name: POSTGRES_DB
+              value: {{ (include "postgresql.database" .) | quote }}
+            {{- end }}
+            {{- if .Values.extraEnv }}
+            {{- include "postgresql.tplValue" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}
+            {{- end }}
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: {{ ternary "yes" "no" .Values.ldap.enabled | quote }}
+            {{- if .Values.ldap.enabled }}
+            - name: POSTGRESQL_LDAP_SERVER
+              value: {{ .Values.ldap.server }}
+            - name: POSTGRESQL_LDAP_PORT
+              value: {{ .Values.ldap.port | quote }}
+            - name: POSTGRESQL_LDAP_SCHEME
+              value: {{ .Values.ldap.scheme }}
+            {{- if .Values.ldap.tls }}
+            - name: POSTGRESQL_LDAP_TLS
+              value: "1"
+            {{- end}}
+            - name: POSTGRESQL_LDAP_PREFIX
+              value: {{ .Values.ldap.prefix | quote }}
+            - name: POSTGRESQL_LDAP_SUFFIX
+              value: {{ .Values.ldap.suffix | quote}}
+            - name: POSTGRESQL_LDAP_BASE_DN
+              value: {{ .Values.ldap.baseDN }}
+            - name: POSTGRESQL_LDAP_BIND_DN
+              value: {{ .Values.ldap.bindDN }}
+            {{- if (not (empty .Values.ldap.bind_password)) }}
+            - name: POSTGRESQL_LDAP_BIND_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-ldap-password
+            {{- end}}
+            - name: POSTGRESQL_LDAP_SEARCH_ATTR
+              value: {{ .Values.ldap.search_attr }}
+            - name: POSTGRESQL_LDAP_SEARCH_FILTER
+              value: {{ .Values.ldap.search_filter }}
+            - name: POSTGRESQL_LDAP_URL
+              value: {{ .Values.ldap.url }}
+            {{- end}}
+          {{- if .Values.extraEnvVarsCM }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.extraEnvVarsCM }}
+          {{- end }}
+          ports:
+            - name: tcp-postgresql
+              containerPort: {{ template "postgresql.port" . }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                {{- if (include "postgresql.database" .) }}
+                - exec pg_isready -U {{ include "postgresql.username" . | quote }} -d {{ (include "postgresql.database" .) | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+                {{- else }}
+                - exec pg_isready -U {{ include "postgresql.username" . | quote }} -h 127.0.0.1 -p {{ template "postgresql.port" . }}
+                {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                {{- include "postgresql.readinessProbeCommand" . | nindent 16 }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d/
+            {{- end }}
+            {{- if .Values.initdbScriptsSecret }}
+            - name: custom-init-scripts-secret
+              mountPath: /docker-entrypoint-initdb.d/secret
+            {{- end }}
+            {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresqlExtendedConf .Values.extendedConfConfigMap }}
+            - name: postgresql-extended-config
+              mountPath: /bitnami/postgresql/conf/conf.d/
+            {{- end }}
+            {{- if .Values.usePasswordFile }}
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            {{- end }}
+            {{- if .Values.shmVolume.enabled }}
+            - name: dshm
+              mountPath: /dev/shm
+            {{- end }}
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              subPath: {{ .Values.persistence.subPath }}
+            {{- end }}
+            {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap }}
+            - name: postgresql-config
+              mountPath: /bitnami/postgresql/conf
+            {{- end }}
+            {{- if .Values.master.extraVolumeMounts }}
+            {{- toYaml .Values.master.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+{{- if .Values.master.sidecars }}
+{{- include "postgresql.tplValue" ( dict "value" .Values.master.sidecars "context" $ ) | nindent 8 }}
+{{- end }}
+{{- if .Values.metrics.enabled }}
+        - name: metrics
+          image: {{ template "postgresql.metrics.image" . }}
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+         {{- if .Values.metrics.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.metrics.securityContext.runAsUser }}
+        {{- end }}
+          env:
+            {{- $database := required "In order to enable metrics you need to specify a database (.Values.postgresqlDatabase or .Values.global.postgresql.postgresqlDatabase)" (include "postgresql.database" .) }}
+            - name: DATA_SOURCE_URI
+              value: {{ printf "127.0.0.1:%d/%s?sslmode=disable" (int (include "postgresql.port" .)) $database | quote }}
+            {{- if .Values.usePasswordFile }}
+            - name: DATA_SOURCE_PASS_FILE
+              value: "/opt/bitnami/postgresql/secrets/postgresql-password"
+            {{- else }}
+            - name: DATA_SOURCE_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "postgresql.secretName" . }}
+                  key: postgresql-password
+            {{- end }}
+            - name: DATA_SOURCE_USER
+              value: {{ template "postgresql.username" . }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http-metrics
+            initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http-metrics
+            initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.usePasswordFile }}
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            {{- end }}
+            {{- if .Values.metrics.customMetrics }}
+            - name: custom-metrics
+              mountPath: /conf
+              readOnly: true
+          args: ["--extend.query-path", "/conf/custom-metrics.yaml"]
+            {{- end }}
+          ports:
+            - name: http-metrics
+              containerPort: 9187
+          {{- if .Values.metrics.resources }}
+          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+          {{- end }}
+{{- end }}
+      volumes:
+        {{- if or (.Files.Glob "files/postgresql.conf") (.Files.Glob "files/pg_hba.conf") .Values.postgresqlConfiguration .Values.pgHbaConfiguration .Values.configurationConfigMap}}
+        - name: postgresql-config
+          configMap:
+            name: {{ template "postgresql.configurationCM" . }}
+        {{- end }}
+        {{- if or (.Files.Glob "files/conf.d/*.conf") .Values.postgresqlExtendedConf .Values.extendedConfConfigMap }}
+        - name: postgresql-extended-config
+          configMap:
+            name: {{ template "postgresql.extendedConfigurationCM" . }}
+        {{- end }}
+        {{- if .Values.usePasswordFile }}
+        - name: postgresql-password
+          secret:
+            secretName: {{ template "postgresql.secretName" . }}
+        {{- end }}
+        {{- if  or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}
+        - name: custom-init-scripts
+          configMap:
+            name: {{ template "postgresql.initdbScriptsCM" . }}
+        {{- end }}
+        {{- if .Values.initdbScriptsSecret }}
+        - name: custom-init-scripts-secret
+          secret:
+            secretName: {{ template "postgresql.initdbScriptsSecret" . }}
+        {{- end }}
+        {{- if .Values.master.extraVolumes }}
+        {{- toYaml .Values.master.extraVolumes | nindent 8 }}
+        {{- end }}
+        {{- if and .Values.metrics.enabled .Values.metrics.customMetrics }}
+        - name: custom-metrics
+          configMap:
+            name: {{ template "postgresql.metricsCM" . }}
+        {{- end }}
+        {{- if .Values.shmVolume.enabled }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Gi
+        {{- end }}
+{{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+{{- with .Values.persistence.existingClaim }}
+            claimName: {{ tpl . $ }}
+{{- end }}
+{{- else if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+{{- else if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      {{- with .Values.persistence.annotations }}
+        annotations:
+        {{- range $key, $value := . }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
+      {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        {{ include "postgresql.storageClass" . }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/svc-headless.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/svc-headless.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "postgresql.fullname" . }}-headless
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: tcp-postgresql
+      port: {{ template "postgresql.port" . }}
+      targetPort: tcp-postgresql
+  selector:
+    app: {{ template "postgresql.name" . }}
+    release: {{ .Release.Name | quote }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/svc-read.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/svc-read.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.replication.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "postgresql.fullname" . }}-read
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: tcp-postgresql
+      port:  {{ template "postgresql.port" . }}
+      targetPort: tcp-postgresql
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    app: {{ template "postgresql.name" . }}
+    release: {{ .Release.Name | quote }}
+    role: slave
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/svc.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/templates/svc.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "postgresql.fullname" . }}
+  labels:
+    app: {{ template "postgresql.name" . }}
+    chart: {{ template "postgresql.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ tpl (toYaml .) $ | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{ with .Values.service.loadBalancerSourceRanges }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  ports:
+    - name: tcp-postgresql
+      port: {{ template "postgresql.port" . }}
+      targetPort: tcp-postgresql
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    app: {{ template "postgresql.name" . }}
+    release: {{ .Release.Name | quote }}
+    role: master

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/values-production.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/values-production.yaml
@@ -3,7 +3,7 @@
 ## Current available global Docker image parameters: imageRegistry and imagePullSecrets
 ##
 global:
-  postgresql: { }
+  postgresql: {}
 #   imageRegistry: myRegistryName
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
@@ -14,8 +14,8 @@ global:
 ##
 image:
   registry: docker.io
-  repository: bitnamilegacy/postgresql
-  tag: 9.6.10-r64
+  repository: bitnami/postgresql
+  tag: 11.7.0-debian-10-r26
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -47,6 +47,32 @@ image:
 ##
 volumePermissions:
   enabled: false
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+  ## Init container Security Context
+  ## Note: the chown of the data folder is done to securityContext.runAsUser
+  ## and not the below volumePermissions.securityContext.runAsUser
+  ## When runAsUser is set to special value "auto", init container will try to chwon the
+  ## data folder to autodetermined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
+  ## "auto" is especially useful for OpenShift which has scc with dynamic userids (and 0 is not allowed).
+  ## You may want to use this volumePermissions.securityContext.runAsUser="auto" in combination with
+  ## pod securityContext.enabled=false and shmVolume.chmod.enabled=false
+  ##
+  securityContext:
+    runAsUser: 0
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
@@ -69,10 +95,10 @@ serviceAccount:
   # name:
 
 replication:
-  enabled: false
+  enabled: true
   user: repl_user
   password: repl_password
-  slaveReplicas: 0
+  slaveReplicas: 2
   ## Set synchronous commit mode: on, off, remote_apply, remote_write and local
   ## ref: https://www.postgresql.org/docs/9.6/runtime-config-wal.html#GUC-WAL-LEVEL
   synchronousCommit: "on"
@@ -96,7 +122,7 @@ postgresqlUsername: postgres
 # postgresqlPassword:
 
 ## PostgreSQL password using existing secret
-existingSecret: postgresql
+## existingSecret: secret
 
 ## Mount PostgreSQL secret as a file instead of passing environment variable
 # usePasswordFile: false
@@ -109,7 +135,7 @@ existingSecret: postgresql
 ## PostgreSQL data dir
 ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md
 ##
-postgresqlDataDir: /opt/bitnami/postgresql/data
+postgresqlDataDir: /bitnami/postgresql/data
 
 ## An array to add extra environment variables
 ## For example:
@@ -222,7 +248,7 @@ service:
 
   ## Provide any additional annotations which may be required.
   ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
-  annotations: { }
+  annotations: {}
   ## Set the LoadBalancer service type to internal only.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
@@ -240,11 +266,15 @@ service:
 ## [docker issue](https://github.com/docker-library/postgres/issues/416) and the
 ## [containerd issue](https://github.com/containerd/containerd/issues/3654),
 ## which could be not enough if PostgreSQL uses parallel workers heavily.
-## If this option is present and value is `true`,
-## to the target database pod will be mounted a new tmpfs volume to remove
-## this limitation.
+##
 shmVolume:
+  ## Set `shmVolume.enabled` to `true` to mount a new tmpfs volume to remove
+  ## this limitation.
+  ##
   enabled: true
+  ## Set to `true` to `chmod 777 /dev/shm` on a initContainer.
+  ## This option is ingored if `volumePermissions.enabled` is `false`
+  ##
   chmod:
     enabled: true
 
@@ -273,11 +303,11 @@ persistence:
   ##
   subPath: ""
 
-  storageClass: "gp2"
+  # storageClass: "-"
   accessModes:
     - ReadWriteOnce
-  size: 75Gi
-  annotations: { }
+  size: 8Gi
+  annotations: {}
 
 ## updateStrategy for PostgreSQL StatefulSet and its slaves StatefulSets
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
@@ -293,28 +323,31 @@ master:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption
-  nodeSelector: { }
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: type
-                operator: In
-                values:
-                  - core
-  tolerations: [ ]
-  labels: { }
-  annotations: { }
-  podLabels: { }
-  podAnnotations: { }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  labels: {}
+  annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   priorityClassName: ""
   ## Additional PostgreSQL Master Volume mounts
   ##
-  extraVolumeMounts: [ ]
+  extraVolumeMounts: []
   ## Additional PostgreSQL Master Volumes
   ##
-  extraVolumes: [ ]
+  extraVolumes: []
+  ## Add sidecars to the pod
+  ##
+  ## For example:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  sidecars: []
 
 ##
 ## PostgreSQL Slave parameters
@@ -325,20 +358,35 @@ slave:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption
-  nodeSelector: { }
-  affinity: { }
-  tolerations: [ ]
-  labels: { }
-  annotations: { }
-  podLabels: { }
-  podAnnotations: { }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  labels: {}
+  annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   priorityClassName: ""
+  extraInitContainers: |
+    # - name: do-something
+    #   image: busybox
+    #   command: ['do', 'something']
   ## Additional PostgreSQL Slave Volume mounts
   ##
-  extraVolumeMounts: [ ]
+  extraVolumeMounts: []
   ## Additional PostgreSQL Slave Volumes
   ##
-  extraVolumes: [ ]
+  extraVolumes: []
+  ## Add sidecars to the pod
+  ##
+  ## For example:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  sidecars: []
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -347,9 +395,6 @@ resources:
   requests:
     memory: 256Mi
     cpu: 250m
-  limits:
-    cpu: 2
-    memory: 8Gi
 
 networkPolicy:
   ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
@@ -363,16 +408,16 @@ networkPolicy:
   ##
   allowExternal: true
 
-    ## if explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
-    ## and that match other criteria, the ones that have the good label, can reach the DB.
-    ## But sometimes, we want the DB to be accessible to clients from other namespaces, in this case, we can use this
-    ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
-    ##
-    # explicitNamespacesSelector:
+  ## if explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+  ## and that match other criteria, the ones that have the good label, can reach the DB.
+  ## But sometimes, we want the DB to be accessible to clients from other namespaces, in this case, we can use this
+  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  ##
+  # explicitNamespacesSelector:
     # matchLabels:
-  # role: frontend
-  # matchExpressions:
-  # - {key: role, operator: In, values: [frontend]}
+      # role: frontend
+    # matchExpressions:
+      # - {key: role, operator: In, values: [frontend]}
 
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
@@ -395,7 +440,7 @@ readinessProbe:
 ## Configure metrics exporter
 ##
 metrics:
-  enabled: false
+  enabled: true
   # resources: {}
   service:
     type: ClusterIP
@@ -405,7 +450,7 @@ metrics:
     loadBalancerIP:
   serviceMonitor:
     enabled: false
-    additionalLabels: { }
+    additionalLabels: {}
     # namespace: monitoring
     # interval: 30s
     # scrapeTimeout: 10s
@@ -414,9 +459,9 @@ metrics:
   ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
   prometheusRule:
     enabled: false
-    additionalLabels: { }
+    additionalLabels: {}
     namespace: ""
-    rules: [ ]
+    rules: []
       ## These are just examples rules, please adapt them to your needs.
       ## Make sure to constraint the rules to the current postgresql service.
       # - alert: HugeReplicationLag
@@ -424,13 +469,13 @@ metrics:
       #   for: 1m
       #   labels:
       #     severity: critical
-    #   annotations:
-    #     description: replication for {{ template "postgresql.fullname" . }} PostgreSQL is lagging by {{ "{{ $value }}" }} hour(s).
-    #     summary: PostgreSQL replication is lagging by {{ "{{ $value }}" }} hour(s).
+      #   annotations:
+      #     description: replication for {{ template "postgresql.fullname" . }} PostgreSQL is lagging by {{ "{{ $value }}" }} hour(s).
+      #     summary: PostgreSQL replication is lagging by {{ "{{ $value }}" }} hour(s).
   image:
     registry: docker.io
     repository: bitnami/postgres-exporter
-    tag: 0.8.0-debian-10-r4
+    tag: 0.8.0-debian-10-r42
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/values.schema.json
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/values.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "postgresqlUsername": {
+      "type": "string",
+      "title": "Admin user",
+      "form": true
+    },
+    "postgresqlPassword": {
+      "type": "string",
+      "title": "Password",
+      "form": true
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "title": "Persistent Volume Size",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderUnit": "Gi"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "title": "Required Resources",
+      "description": "Configure resource requests",
+      "form": true,
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "Memory Request",
+              "sliderMin": 10,
+              "sliderMax": 2048,
+              "sliderUnit": "Mi"
+            },
+            "cpu": {
+              "type": "string",
+              "form": true,
+              "render": "slider",
+              "title": "CPU Request",
+              "sliderMin": 10,
+              "sliderMax": 2000,
+              "sliderUnit": "m"
+            }
+          }
+        }
+      }
+    },
+    "replication": {
+      "type": "object",
+      "form": true,
+      "title": "Replication Details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enable Replication",
+          "form": true
+        },
+        "slaveReplicas": {
+          "type": "integer",
+          "title": "Slave Replicas",
+          "form": true,
+          "hidden": {
+            "condition": false,
+            "value": "replication.enabled"
+          }
+        }
+      }
+    },
+    "volumePermissions": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable Init Containers",
+          "description": "Change the owner of the persist volume mountpoint to RunAsUser:fsGroup"
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Configure metrics exporter",
+          "form": true
+        }
+      }
+    }
+  }
+}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/values.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/postgresql/values.yaml
@@ -3,7 +3,7 @@
 ## Current available global Docker image parameters: imageRegistry and imagePullSecrets
 ##
 global:
-  postgresql: { }
+  postgresql: {}
 #   imageRegistry: myRegistryName
 #   imagePullSecrets:
 #     - myRegistryKeySecretName
@@ -14,8 +14,8 @@ global:
 ##
 image:
   registry: docker.io
-  repository: bitnamilegacy/postgresql
-  tag: 9.6.10-r64
+  repository: bitnami/postgresql
+  tag: 11.7.0-debian-10-r26
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -47,11 +47,38 @@ image:
 ##
 volumePermissions:
   enabled: false
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+  ## Init container Security Context
+  ## Note: the chown of the data folder is done to securityContext.runAsUser
+  ## and not the below volumePermissions.securityContext.runAsUser
+  ## When runAsUser is set to special value "auto", init container will try to chwon the
+  ## data folder to autodetermined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
+  ## "auto" is especially useful for OpenShift which has scc with dynamic userids (and 0 is not allowed).
+  ## You may want to use this volumePermissions.securityContext.runAsUser="auto" in combination with
+  ## pod securityContext.enabled=false and shmVolume.chmod.enabled=false
+  ##
+  securityContext:
+    runAsUser: 0
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##
 # schedulerName:
+
 
 ## Pod Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -72,13 +99,13 @@ replication:
   enabled: false
   user: repl_user
   password: repl_password
-  slaveReplicas: 0
+  slaveReplicas: 1
   ## Set synchronous commit mode: on, off, remote_apply, remote_write and local
   ## ref: https://www.postgresql.org/docs/9.6/runtime-config-wal.html#GUC-WAL-LEVEL
-  synchronousCommit: "on"
+  synchronousCommit: "off"
   ## From the number of `slaveReplicas` defined above, set the number of those that will have synchronous replication
   ## NOTE: It cannot be > slaveReplicas
-  numSynchronousReplicas: 1
+  numSynchronousReplicas: 0
   ## Replication Cluster application name. Useful for defining multiple replication policies
   applicationName: my_application
 
@@ -96,7 +123,7 @@ postgresqlUsername: postgres
 # postgresqlPassword:
 
 ## PostgreSQL password using existing secret
-existingSecret: postgresql
+## existingSecret: secret
 
 ## Mount PostgreSQL secret as a file instead of passing environment variable
 # usePasswordFile: false
@@ -109,7 +136,7 @@ existingSecret: postgresql
 ## PostgreSQL data dir
 ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md
 ##
-postgresqlDataDir: /opt/bitnami/postgresql/data
+postgresqlDataDir: /bitnami/postgresql/data
 
 ## An array to add extra environment variables
 ## For example:
@@ -174,10 +201,6 @@ extraEnv: []
 #      #!/bin/sh
 #      echo "Do something."
 
-## Specify the PostgreSQL username and password to execute the initdb scripts
-# initdbUser:
-# initdbPassword:
-
 ## ConfigMap with scripts to be run at first boot
 ## NOTE: This will override initdbScripts
 # initdbScriptsConfigMap:
@@ -185,6 +208,10 @@ extraEnv: []
 ## Secret with scripts to be run at first boot (in case it contains sensitive information)
 ## NOTE: This can work along initdbScripts or initdbScriptsConfigMap
 # initdbScriptsSecret:
+
+## Specify the PostgreSQL username and password to execute the initdb scripts
+# initdbUser:
+# initdbPassword:
 
 ## Optional duration in seconds the pod needs to terminate gracefully.
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
@@ -222,7 +249,7 @@ service:
 
   ## Provide any additional annotations which may be required.
   ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
-  annotations: { }
+  annotations: {}
   ## Set the LoadBalancer service type to internal only.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
@@ -240,11 +267,15 @@ service:
 ## [docker issue](https://github.com/docker-library/postgres/issues/416) and the
 ## [containerd issue](https://github.com/containerd/containerd/issues/3654),
 ## which could be not enough if PostgreSQL uses parallel workers heavily.
-## If this option is present and value is `true`,
-## to the target database pod will be mounted a new tmpfs volume to remove
-## this limitation.
+##
 shmVolume:
+  ## Set `shmVolume.enabled` to `true` to mount a new tmpfs volume to remove
+  ## this limitation.
+  ##
   enabled: true
+  ## Set to `true` to `chmod 777 /dev/shm` on a initContainer.
+  ## This option is ingored if `volumePermissions.enabled` is `false`
+  ##
   chmod:
     enabled: true
 
@@ -273,11 +304,11 @@ persistence:
   ##
   subPath: ""
 
-  storageClass: "gp2"
+  # storageClass: "-"
   accessModes:
     - ReadWriteOnce
-  size: 75Gi
-  annotations: { }
+  size: 8Gi
+  annotations: {}
 
 ## updateStrategy for PostgreSQL StatefulSet and its slaves StatefulSets
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
@@ -293,28 +324,36 @@ master:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption
-  nodeSelector: { }
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: type
-                operator: In
-                values:
-                  - core
-  tolerations: [ ]
-  labels: { }
-  annotations: { }
-  podLabels: { }
-  podAnnotations: { }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  labels: {}
+  annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   priorityClassName: ""
+  extraInitContainers: |
+    # - name: do-something
+    #   image: busybox
+    #   command: ['do', 'something']
+
   ## Additional PostgreSQL Master Volume mounts
   ##
-  extraVolumeMounts: [ ]
+  extraVolumeMounts: []
   ## Additional PostgreSQL Master Volumes
   ##
-  extraVolumes: [ ]
+  extraVolumes: []
+  ## Add sidecars to the pod
+  ##
+  ## For example:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  sidecars: []
 
 ##
 ## PostgreSQL Slave parameters
@@ -325,20 +364,35 @@ slave:
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption
-  nodeSelector: { }
-  affinity: { }
-  tolerations: [ ]
-  labels: { }
-  annotations: { }
-  podLabels: { }
-  podAnnotations: { }
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  labels: {}
+  annotations: {}
+  podLabels: {}
+  podAnnotations: {}
   priorityClassName: ""
+  extraInitContainers: |
+    # - name: do-something
+    #   image: busybox
+    #   command: ['do', 'something']
   ## Additional PostgreSQL Slave Volume mounts
   ##
-  extraVolumeMounts: [ ]
+  extraVolumeMounts: []
   ## Additional PostgreSQL Slave Volumes
   ##
-  extraVolumes: [ ]
+  extraVolumes: []
+  ## Add sidecars to the pod
+  ##
+  ## For example:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  sidecars: []
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -347,9 +401,6 @@ resources:
   requests:
     memory: 256Mi
     cpu: 250m
-  limits:
-    cpu: 2
-    memory: 8Gi
 
 networkPolicy:
   ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
@@ -363,16 +414,16 @@ networkPolicy:
   ##
   allowExternal: true
 
-    ## if explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
-    ## and that match other criteria, the ones that have the good label, can reach the DB.
-    ## But sometimes, we want the DB to be accessible to clients from other namespaces, in this case, we can use this
-    ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
-    ##
-    # explicitNamespacesSelector:
+  ## if explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+  ## and that match other criteria, the ones that have the good label, can reach the DB.
+  ## But sometimes, we want the DB to be accessible to clients from other namespaces, in this case, we can use this
+  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  ##
+  # explicitNamespacesSelector:
     # matchLabels:
-  # role: frontend
-  # matchExpressions:
-  # - {key: role, operator: In, values: [frontend]}
+      # role: frontend
+    # matchExpressions:
+      # - {key: role, operator: In, values: [frontend]}
 
 ## Configure extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
@@ -405,7 +456,7 @@ metrics:
     loadBalancerIP:
   serviceMonitor:
     enabled: false
-    additionalLabels: { }
+    additionalLabels: {}
     # namespace: monitoring
     # interval: 30s
     # scrapeTimeout: 10s
@@ -414,9 +465,9 @@ metrics:
   ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
   prometheusRule:
     enabled: false
-    additionalLabels: { }
+    additionalLabels: {}
     namespace: ""
-    rules: [ ]
+    rules: []
       ## These are just examples rules, please adapt them to your needs.
       ## Make sure to constraint the rules to the current postgresql service.
       # - alert: HugeReplicationLag
@@ -424,13 +475,13 @@ metrics:
       #   for: 1m
       #   labels:
       #     severity: critical
-    #   annotations:
-    #     description: replication for {{ template "postgresql.fullname" . }} PostgreSQL is lagging by {{ "{{ $value }}" }} hour(s).
-    #     summary: PostgreSQL replication is lagging by {{ "{{ $value }}" }} hour(s).
+      #   annotations:
+      #     description: replication for {{ template "postgresql.fullname" . }} PostgreSQL is lagging by {{ "{{ $value }}" }} hour(s).
+      #     summary: PostgreSQL replication is lagging by {{ "{{ $value }}" }} hour(s).
   image:
     registry: docker.io
     repository: bitnami/postgres-exporter
-    tag: 0.8.0-debian-10-r4
+    tag: 0.8.0-debian-10-r42
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/Chart.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+name: rabbitmq
+version: 6.18.2
+appVersion: 3.8.2
+description: Open source message broker software that implements the Advanced Message Queuing Protocol (AMQP)
+keywords:
+- rabbitmq
+- message queue
+- AMQP
+home: https://www.rabbitmq.com
+icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
+sources:
+- https://github.com/bitnami/bitnami-docker-rabbitmq
+maintainers:
+- name: Bitnami
+  email: containers@bitnami.com
+engine: gotpl

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/README.md
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/README.md
@@ -1,0 +1,421 @@
+# RabbitMQ
+
+[RabbitMQ](https://www.rabbitmq.com/) is an open source message broker software that implements the Advanced Message Queuing Protocol (AMQP).
+
+## TL;DR;
+
+```bash
+$ helm install my-release bitnami/rabbitmq
+```
+
+## Introduction
+
+This chart bootstraps a [RabbitMQ](https://github.com/bitnami/bitnami-docker-rabbitmq) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This chart has been tested to work with NGINX Ingress, cert-manager, fluentd and Prometheus on top of the [BKPR](https://kubeprod.io/).
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 2.11+ or Helm 3.0-beta3+
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install my-release bitnami/rabbitmq
+```
+
+The command deploys RabbitMQ on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+The following table lists the configurable parameters of the RabbitMQ chart and their default values.
+
+| Parameter                                    | Description                                      | Default                                                 |
+| -------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------- |
+| `global.imageRegistry`                       | Global Docker image registry                     | `nil`                                                   |
+| `global.imagePullSecrets`                    | Global Docker registry secret names as an array  | `[]` (does not add image pull secrets to deployed pods) |
+| `global.storageClass`                        | Global storage class for dynamic provisioning    | `nil`                                                   |
+| `image.registry`                             | Rabbitmq Image registry                          | `docker.io`                                             |
+| `image.repository`                           | Rabbitmq Image name                              | `bitnami/rabbitmq`                                      |
+| `image.tag`                                  | Rabbitmq Image tag                               | `{TAG_NAME}`                                            |
+| `image.pullPolicy`                           | Image pull policy                                | `IfNotPresent`                                          |
+| `image.pullSecrets`                          | Specify docker-registry secret names as an array | `nil`                                                   |
+| `image.debug`                                | Specify if debug values should be set            | `false`                                                 |
+| `nameOverride`                               | String to partially override rabbitmq.fullname template with a string (will prepend the release name) | `nil` |
+| `fullnameOverride`                           | String to fully override rabbitmq.fullname template with a string                                     | `nil` |
+| `rbacEnabled`                                | Specify if rbac is enabled in your cluster       | `true`                                                  |
+| `podManagementPolicy`                        | Pod management policy                            | `OrderedReady`                                          |
+| `rabbitmq.username`                          | RabbitMQ application username                    | `user`                                                  |
+| `rabbitmq.password`                          | RabbitMQ application password                    | _random 10 character long alphanumeric string_          |
+| `rabbitmq.existingPasswordSecret`            | Existing secret with RabbitMQ credentials        | `nil`                                                   |
+| `rabbitmq.erlangCookie`                      | Erlang cookie                                    | _random 32 character long alphanumeric string_          |
+| `rabbitmq.existingErlangSecret`              | Existing secret with RabbitMQ Erlang cookie      | `nil`                                                   |
+| `rabbitmq.plugins`                           | List of plugins to enable                        | `rabbitmq_management rabbitmq_peer_discovery_k8s`       |
+| `rabbitmq.extraPlugins`                      | Extra plugings to enable                         | `nil`                                                   |
+| `rabbitmq.clustering.address_type`           | Switch clustering mode                           | `ip` or `hostname`                                      |
+| `rabbitmq.clustering.k8s_domain`             | Customize internal k8s cluster domain            | `cluster.local`                                         |
+| `rabbitmq.clustering.rebalance`              | Rebalance master for queues in cluster when new replica is created            | `false`                                         |
+| `rabbitmq.logs`                              | Value for the RABBITMQ_LOGS environment variable | `-`                                                     |
+| `rabbitmq.setUlimitNofiles`                  | Specify if max file descriptor limit should be set | `true`                                                |
+| `rabbitmq.ulimitNofiles`                     | Max File Descriptor limit                        | `65536`                                                 |
+| `rabbitmq.maxAvailableSchedulers`            | RabbitMQ maximum available scheduler threads     | `2`                                                     |
+| `rabbitmq.onlineSchedulers`                  | RabbitMQ online scheduler threads                | `1`                                                     |
+| `rabbitmq.env`                               | RabbitMQ [environment variables](https://www.rabbitmq.com/configure.html#customise-environment) | `{}`     |
+| `rabbitmq.configuration`                     | Required cluster configuration                   | See values.yaml                                         |
+| `rabbitmq.extraConfiguration`                | Extra configuration to add to rabbitmq.conf      | See values.yaml                                         |
+| `rabbitmq.advancedConfiguration`             | Extra configuration (in classic format) to add to advanced.config    | See values.yaml                     |
+| `rabbitmq.tls.enabled`                       | Enable TLS support to rabbitmq                   | `false`                                                 |
+| `rabbitmq.tls.failIfNoPeerCert`              | When set to true, TLS connection will be rejected if client fails to provide a certificate  | `true`       |
+| `rabbitmq.tls.sslOptionsVerify`              | `verify_peer`  | Should [peer verification](https://www.rabbitmq.com/ssl.html#peer-verification) be enabled? |
+| `rabbitmq.tls.caCertificate`                 | Ca certificate                                   | Certificate Authority (CA) bundle content               |
+| `rabbitmq.tls.serverCertificate`             | Server certificate                               | Server certificate content                              |
+| `rabbitmq.tls.serverKey`                     | Server Key                                       | Server private key content                              |
+| `rabbitmq.tls.existingSecret`                | Existing secret with certificate content to rabbitmq credentials  | `nil`                                  |
+| `ldap.enabled`                               | Enable LDAP support                              | `false`                                                 |
+| `ldap.server`                                | LDAP server                                      | `""`                                                    |
+| `ldap.port`                                  | LDAP port                                        | `389`                                                   |
+| `ldap.user_dn_pattern`                       | DN used to bind to LDAP                          | `cn=${username},dc=example,dc=org`                      |
+| `ldap.tls.enabled`                           | Enable TLS for LDAP connections                  | `false` (if set to true, check advancedConfiguration parameter in values.yml)   |
+| `service.type`                               | Kubernetes Service type                          | `ClusterIP`                                             |
+| `service.port`                               | Amqp port                                        | `5672`                                                  |
+| `service.loadBalancerIP`                    | LoadBalancerIP for the service                   | `nil`                                                   |
+| `service.tlsPort`                            | Amqp TLS port                                    | `5671`                                                  |
+| `service.distPort`                           | Erlang distribution server port                  | `25672`                                                 |
+| `service.nodePort`                           | Node port override, if serviceType NodePort      | _random available between 30000-32767_                  |
+| `service.nodeTlsPort`                        | Node port override, if serviceType NodePort      | _random available between 30000-32767_                  |
+| `service.managerPort`                        | RabbitMQ Manager port                            | `15672`                                                 |
+| `service.extraPorts`                         | Extra ports to expose in the service             | `nil`                                                   |
+| `service.extraContainerPorts`                | Extra ports to be included in container spec, primarily informational   | `nil`                            |
+| `persistence.enabled`                        | Use a PVC to persist data                        | `true`                                                  |
+| `service.annotations`                        | service annotations                              | {}                                                      |
+| `schedulerName`                              | Name of the k8s service (other than default)     | `nil`                                                   |
+| `persistence.storageClass`                   | Storage class of backing PVC                     | `nil` (uses alpha storage class annotation)             |
+| `persistence.existingClaim`                  | RabbitMQ data Persistent Volume existing claim name, evaluated as a template |  ""                         |
+| `persistence.accessMode`                     | Use volume as ReadOnly or ReadWrite              | `ReadWriteOnce`                                         |
+| `persistence.size`                           | Size of data volume                              | `8Gi`                                                   |
+| `persistence.path`                           | Mount path of the data volume                    | `/opt/bitnami/rabbitmq/var/lib/rabbitmq`                |
+| `securityContext.enabled`                    | Enable security context                          | `true`                                                  |
+| `securityContext.fsGroup`                    | Group ID for the container                       | `1001`                                                  |
+| `securityContext.runAsUser`                  | User ID for the container                        | `1001`                                                  |
+| `resources`                                  | resource needs and limits to apply to the pod    | {}                                                      |
+| `replicas`                                   | Replica count                                    | `1`                                                     |
+| `priorityClassName`                          | Pod priority class name                          | ``                                                      |
+| `networkPolicy.enabled`                      | Enable NetworkPolicy                             | `false`                                                 |
+| `networkPolicy.allowExternal`                | Don't require client label for connections       | `true`                                                  |
+| `networkPolicy.additionalRules`              | Additional NetworkPolicy rules                   | `nil`                                                   |
+| `nodeSelector`                               | Node labels for pod assignment                   | {}                                                      |
+| `affinity`                                   | Affinity settings for pod assignment             | {}                                                      |
+| `tolerations`                                | Toleration labels for pod assignment             | []                                                      |
+| `updateStrategy`                             | Statefulset update strategy policy               | `RollingUpdate`                                         |
+| `ingress.enabled`                            | Enable ingress resource for Management console   | `false`                                                 |
+| `ingress.hostName`                           | Hostname to your RabbitMQ installation           | `nil`                                                   |
+| `ingress.path`                               | Path within the url structure                    | `/`                                                     |
+| `ingress.tls`                                | enable ingress with tls                          | `false`                                                 |
+| `ingress.tlsSecret`                          | tls type secret to be used                       | `myTlsSecret`                                           |
+| `ingress.annotations`                        | ingress annotations as an array                  | []                                                      |
+| `livenessProbe.enabled`                      | would you like a livenessProbed to be enabled    | `true`                                                  |
+| `livenessProbe.initialDelaySeconds`          | number of seconds                                | 120                                                     |
+| `livenessProbe.timeoutSeconds`               | number of seconds                                | 20                                                      |
+| `livenessProbe.periodSeconds`                | number of seconds                                | 30                                                      |
+| `livenessProbe.failureThreshold`             | number of failures                               | 6                                                       |
+| `livenessProbe.successThreshold`             | number of successes                              | 1                                                       |
+| `podDisruptionBudget`                        | Pod Disruption Budget settings                   | {}                                                      |
+| `readinessProbe.enabled`                     | would you like a readinessProbe to be enabled    | `true`                                                  |
+| `readinessProbe.initialDelaySeconds`         | number of seconds                                | 10                                                      |
+| `readinessProbe.timeoutSeconds`              | number of seconds                                | 20                                                      |
+| `readinessProbe.periodSeconds`               | number of seconds                                | 30                                                      |
+| `readinessProbe.failureThreshold`            | number of failures                               | 3                                                       |
+| `readinessProbe.successThreshold`            | number of successes                              | 1                                                       |
+| `metrics.enabled`                            | Start a side-car prometheus exporter             | `false`                                                 |
+| `metrics.image.registry`                     | Exporter image registry                          | `docker.io`                                             |
+| `metrics.image.repository`                   | Exporter image name                              | `bitnami/rabbitmq-exporter`                             |
+| `metrics.image.tag`                          | Exporter image tag                               | `{TAG_NAME}`                                            |
+| `metrics.image.pullPolicy`                   | Exporter image pull policy                       | `IfNotPresent`                                          |
+| `metrics.livenessProbe.enabled`              | would you like a livenessProbed to be enabled    | `true`                                                  |
+| `metrics.livenessProbe.initialDelaySeconds`  | number of seconds                                | 15                                                      |
+| `metrics.livenessProbe.timeoutSeconds`       | number of seconds                                | 5                                                       |
+| `metrics.livenessProbe.periodSeconds`        | number of seconds                                | 30                                                      |
+| `metrics.livenessProbe.failureThreshold`     | number of failures                               | 6                                                       |
+| `metrics.livenessProbe.successThreshold`     | number of successes                              | 1                                                       |
+| `metrics.readinessProbe.enabled`             | would you like a readinessProbe to be enabled    | `true`                                                  |
+| `metrics.readinessProbe.initialDelaySeconds` | number of seconds                                | 5                                                       |
+| `metrics.readinessProbe.timeoutSeconds`      | number of seconds                                | 5                                                       |
+| `metrics.readinessProbe.periodSeconds`       | number of seconds                                | 30                                                      |
+| `metrics.readinessProbe.failureThreshold`    | number of failures                               | 3                                                       |
+| `metrics.readinessProbe.successThreshold`    | number of successes                              | 1                                                       |
+| `metrics.serviceMonitor.enabled`             | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator   | `false`                   |
+| `metrics.serviceMonitor.namespace`           | Namespace where servicemonitor resource should be created                      | `nil`                     |
+| `metrics.serviceMonitor.interval`            | Specify the interval at which metrics should be scraped                        | `30s`                     |
+| `metrics.serviceMonitor.scrapeTimeout`       | Specify the timeout after which the scrape is ended                            | `nil`                     |
+| `metrics.serviceMonitor.relabellings`        | Specify Metric Relabellings to add to the scrape endpoint                      | `nil`                     |
+| `metrics.serviceMonitor.honorLabels`         | honorLabels chooses the metric's labels on collisions with target labels.      | `false`                   |
+| `metrics.serviceMonitor.additionalLabels`    | Used to pass Labels that are required by the Installed Prometheus Operator     | `{}`                      |
+| `metrics.serviceMonitor.release`             | Used to pass Labels release that sometimes should be custom for Prometheus Operator     | `nil`                      |
+| `metrics.prometheusRule.enabled`             | Set this to true to create prometheusRules for Prometheus operator                                                              | `false`                    |
+| `metrics.prometheusRule.additionalLabels`    | Additional labels that can be used so prometheusRules will be discovered by Prometheus                                          | `{}`                       |
+| `metrics.prometheusRule.namespace`           | namespace where prometheusRules resource should be created                                                                      | Same namespace as rabbitmq |
+| `metrics.prometheusRule.rules`               | [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created, check values for an example.  | `[]`                       |
+| `metrics.port`                               | Prometheus metrics exporter port                 | `9419`                                                  |
+| `metrics.env`                                | Exporter [configuration environment variables](https://github.com/kbudde/rabbitmq_exporter#configuration) | `{}` |
+| `metrics.resources`                          | Exporter resource requests/limit                 | `nil`                                                   |
+| `metrics.capabilities`                       | Exporter: Comma-separated list of extended [scraping capabilities supported by the target RabbitMQ server](https://github.com/kbudde/rabbitmq_exporter#extended-rabbitmq-capabilities) | `bert,no_sort` |
+| `podLabels`                                  | Additional labels for the statefulset pod(s).    | {}                                                      |
+| `volumePermissions.enabled`                  | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false |
+| `volumePermissions.image.registry`           | Init container volume-permissions image registry     | `docker.io`                                         |
+| `volumePermissions.image.repository`         | Init container volume-permissions image name         | `bitnami/minideb`                                   |
+| `volumePermissions.image.tag`                | Init container volume-permissions image tag          | `buster`                                            |
+| `volumePermissions.image.pullPolicy`         | Init container volume-permissions image pull policy  | `Always`                                            |
+| `volumePermissions.resources`                | Init container resource requests/limit               | `nil`                                               |
+| `forceBoot.enabled`                          | Executes 'rabbitmqctl force_boot' to force boot cluster shut down unexpectedly in an unknown order. Use it only if you prefer availability over integrity. | `false` |
+| `extraSecrets`                               | Optionally specify extra secrets to be created by the chart. | `{}`                                        |
+
+The above parameters map to the env variables defined in [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq). For more information please refer to the [bitnami/rabbitmq](http://github.com/bitnami/bitnami-docker-rabbitmq) image documentation.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install my-release \
+  --set rabbitmq.username=admin,rabbitmq.password=secretpassword,rabbitmq.erlangCookie=secretcookie \
+    bitnami/rabbitmq
+```
+
+The above command sets the RabbitMQ admin username and password to `admin` and `secretpassword` respectively. Additionally the secure erlang cookie is set to `secretcookie`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install my-release -f values.yaml bitnami/rabbitmq
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Configuration and installation details
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+### Production configuration and horizontal scaling
+
+This chart includes a `values-production.yaml` file where you can find some parameters oriented to production configuration in comparison to the regular `values.yaml`. You can use this file instead of the default one.
+
+- Resource needs and limits to apply to the pod:
+```diff
+- resources: {}
++ resources:
++   requests:
++     memory: 256Mi
++     cpu: 100m
+```
+
+- Replica count:
+```diff
+- replicas: 1
++ replicas: 3
+```
+
+- Node labels for pod assignment:
+```diff
+- nodeSelector: {}
++ nodeSelector:
++   beta.kubernetes.io/arch: amd64
+```
+
+- Enable ingress with TLS:
+```diff
+- ingress.tls: false
++ ingress.tls: true
+```
+
+- Start a side-car prometheus exporter:
+```diff
+- metrics.enabled: false
++ metrics.enabled: true
+```
+
+- Enable init container that changes volume permissions in the data directory:
+```diff
+- volumePermissions.enabled: false
++ volumePermissions.enabled: true
+```
+
+To horizontally scale this chart once it has been deployed you have two options:
+
+- Use `kubectl scale` command
+
+- Upgrading the chart with the following parameters:
+
+```console
+replicas=3
+rabbitmq.password="$RABBITMQ_PASSWORD"
+rabbitmq.erlangCookie="$RABBITMQ_ERLANG_COOKIE"
+```
+
+> Note: please note it's mandatory to indicate the password and erlangCookie that was set the first time the chart was installed to upgrade the chart. Otherwise, new pods won't be able to join the cluster.
+
+### Load Definitions
+It is possible to [load a RabbitMQ definitions file to configure RabbitMQ](http://www.rabbitmq.com/management.html#load-definitions). Because definitions may contain RabbitMQ credentials, [store the JSON as a Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-files-from-a-pod). Within the secret's data, choose a key name that corresponds with the desired load definitions filename (i.e. `load_definition.json`) and use the JSON object as the value. For example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rabbitmq-load-definition
+type: Opaque
+stringData:
+  load_definition.json: |-
+    {
+      "vhosts": [
+        {
+          "name": "/"
+        }
+      ]
+    }
+```
+
+Then, specify the `management.load_definitions` property as an `extraConfiguration` pointing to the load definition file path within the container (i.e. `/app/load_definition.json`) and set `loadDefinition.enable` to `true`.
+
+Any load definitions specified will be available within in the container at `/app`.
+
+> Loading a definition will take precedence over any configuration done through [Helm values](#parameters).
+
+If needed, you can use `extraSecrets` to let the chart create the secret for you. This way, you don't need to manually create it before deploying a release. For example :
+
+```yaml
+extraSecrets:
+  load-definition:
+    load_definition.json: |
+      {
+        "vhosts": [
+          {
+            "name": "/"
+          }
+        ]
+      }
+rabbitmq:
+  loadDefinition:
+    enabled: true
+    secretName: load-definition
+  extraConfiguration: |
+    management.load_definitions = /app/load_definition.json
+```
+
+### Enabling TLS support
+
+To enable TLS support you must generate the certificates using RabbitMQ [documentation](https://www.rabbitmq.com/ssl.html#automated-certificate-generation).
+
+You must include in your values.yaml the caCertificate, serverCertificate and serverKey files.
+
+```yaml
+  caCertificate: |-
+    -----BEGIN CERTIFICATE-----
+    MIIDRTCCAi2gAwIBAgIJAJPh+paO6a3cMA0GCSqGSIb3DQEBCwUAMDExIDAeBgNV
+    ...
+    -----END CERTIFICATE-----
+  serverCertificate: |-
+    -----BEGIN CERTIFICATE-----
+    MIIDqjCCApKgAwIBAgIBATANBgkqhkiG9w0BAQsFADAxMSAwHgYDVQQDDBdUTFNH
+    ...
+    -----END CERTIFICATE-----
+  serverKey: |-
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEpAIBAAKCAQEA2iX3M4d3LHrRAoVUbeFZN3EaGzKhyBsz7GWwTgETiNj+AL7p
+    ....
+    -----END RSA PRIVATE KEY-----
+```
+
+This will be generate a secret with the certs, but is possible specify an existing secret using `existingSecret: name-of-existing-secret-to-rabbitmq`. The secret is of type `kubernetes.io/tls`.
+
+Disabling [failIfNoPeerCert](https://www.rabbitmq.com/ssl.html#peer-verification-configuration) allows a TLS connection if client fails to provide a certificate
+
+[sslOptionsVerify](https://www.rabbitmq.com/ssl.html#peer-verification-configuration): When the sslOptionsVerify option is set to verify_peer, the client does send us a certificate, the node must perform peer verification. When set to verify_none, peer verification will be disabled and certificate exchange won't be performed.
+
+### LDAP
+
+LDAP support can be enabled in the chart by specifying the `ldap.` parameters while creating a release. The following parameters should be configured to properly enable the LDAP support in the chart.
+
+- `ldap.enabled`: Enable LDAP support. Defaults to `false`.
+- `ldap.server`: LDAP server host. No defaults.
+- `ldap.port`: LDAP server port. `389`.
+- `ldap.user_dn_pattern`: DN used to bind to LDAP. `cn=${username},dc=example,dc=org`.
+- `ldap.tls.enabled`: Enable TLS for LDAP connections. Defaults to `false`.
+
+For example:
+
+```console
+ldap.enabled="true"
+ldap.server="my-ldap-server"
+ldap.port="389"
+ldap.user_dn_pattern="cn=${username},dc=example,dc=org"
+```
+
+If `ldap.tls.enabled` is set to true, consider using `ldap.port=636` and checking the settings in the advancedConfiguration.
+
+### Common issues
+
+- Changing the password through RabbitMQ's UI can make the pod fail due to the default liveness probes. If you do so, remember to make the chart aware of the new password. Updating the default secret with the password you set through RabbitMQ's UI will automatically recreate the pods. If you are using your own secret, you may have to manually recreate the pods.
+
+## Persistence
+
+The [Bitnami RabbitMQ](https://github.com/bitnami/bitnami-docker-rabbitmq) image stores the RabbitMQ data and configurations at the `/opt/bitnami/rabbitmq/var/lib/rabbitmq/` path of the container.
+
+The chart mounts a [Persistent Volume](http://kubernetes.io/docs/user-guide/persistent-volumes/) at this location. By default, the volume is created using dynamic volume provisioning. An existing PersistentVolumeClaim can also be defined.
+
+### Existing PersistentVolumeClaims
+
+1. Create the PersistentVolume
+1. Create the PersistentVolumeClaim
+1. Install the chart
+
+```bash
+$ helm install my-release --set persistence.existingClaim=PVC_NAME bitnami/rabbitmq
+```
+
+### Adjust permissions of the persistence volume mountpoint
+
+As the image runs as non-root by default, it is necessary to adjust the ownership of the persistent volume so that the container can write data into it.
+
+By default, the chart is configured to use Kubernetes Security Context to automatically change the ownership of the volume. However, this feature does not work in all Kubernetes distributions.
+As an alternative, this chart supports using an `initContainer` to change the ownership of the volume before mounting it in the final destination.
+
+You can enable this `initContainer` by setting `volumePermissions.enabled` to `true`.
+
+## Upgrading
+
+### To 6.0.0
+
+This new version updates the RabbitMQ image to a [new version based on bash instead of node.js](https://github.com/bitnami/bitnami-docker-rabbitmq#3715-r18-3715-ol-7-r19). However, since this Chart overwrites the container's command, the changes to the container shouldn't affect the Chart. To upgrade, it may be needed to enable the `fastBoot` option, as it is already the case from upgrading from 5.X to 5.Y.
+
+### To 5.0.0
+
+This major release changes the clustering method from `ip` to `hostname`.
+This change is needed to fix the persistence. The data dir will now depend on the hostname which is stable instead of the pod IP that might change.
+
+> IMPORTANT: Note that if you upgrade from a previous version you will lose your data.
+
+### To 3.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 3.0.0. The following example assumes that the release name is rabbitmq:
+
+```console
+$ kubectl delete statefulset rabbitmq --cascade=false
+```

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/ci/affinity-toleration-values.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/ci/affinity-toleration-values.yaml
@@ -1,0 +1,14 @@
+tolerations:
+  - key: foo
+    operator: "Equal"
+    value: bar
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      preference:
+        matchExpressions:
+        - key: foo
+          operator: In
+          values:
+          - bar

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/ci/default-values.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Leave this file empty to ensure that CI runs builds against the default configuration in values.yaml.

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/ci/networkpolicy-values.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/ci/networkpolicy-values.yaml
@@ -1,0 +1,11 @@
+networkPolicy:
+  enable: true
+  allowExternal: false
+  additionalRules:
+    - matchLabels:
+      - role: foo
+    - matchExpressions:
+      - key: role
+        operator: In
+        values:
+          - bar

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/NOTES.txt
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/NOTES.txt
@@ -1,0 +1,79 @@
+
+** Please be patient while the chart is being deployed **
+
+Credentials:
+
+    Username      : {{ .Values.rabbitmq.username }}
+    echo "Password      : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)"
+    echo "ErLang Cookie : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)"
+
+RabbitMQ can be accessed within the cluster on port {{ .Values.service.nodePort }} at {{ template "rabbitmq.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.rabbitmq.clustering.k8s_domain }}
+
+To access for outside the cluster, perform the following steps:
+
+{{- if contains "NodePort" .Values.service.type }}
+
+Obtain the NodePort IP and ports:
+
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_PORT_AMQP=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "rabbitmq.fullname" . }})
+    export NODE_PORT_STATS=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[3].nodePort}" services {{ template "rabbitmq.fullname" . }})
+
+To Access the RabbitMQ AMQP port:
+
+    echo "URL : amqp://$NODE_IP:$NODE_PORT_AMQP/"
+
+To Access the RabbitMQ Management interface:
+
+    echo "URL : http://$NODE_IP:$NODE_PORT_STATS/"
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+Obtain the LoadBalancer IP:
+
+NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+      Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "rabbitmq.fullname" . }}'
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+
+To Access the RabbitMQ AMQP port:
+
+    echo "URL : amqp://$SERVICE_IP:{{ .Values.service.port }}/"
+
+To Access the RabbitMQ Management interface:
+
+    echo "URL : http://$SERVICE_IP:{{ .Values.service.managerPort }}/"
+
+{{- else if contains "ClusterIP"  .Values.service.type }}
+
+To Access the RabbitMQ AMQP port:
+
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "rabbitmq.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+    echo "URL : amqp://127.0.0.1:{{ .Values.service.port }}/"
+
+To Access the RabbitMQ Management interface:
+
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "rabbitmq.fullname" . }} {{ .Values.service.managerPort }}:{{ .Values.service.managerPort }}
+    echo "URL : http://127.0.0.1:{{ .Values.service.managerPort }}/"
+
+{{- end }}
+
+{{- if .Values.metrics.enabled }}
+
+To access the RabbitMQ Prometheus metrics, get the RabbitMQ Prometheus exporter URL by running:
+
+    echo "Prometheus Metrics URL: http://127.0.0.1:{{ .Values.metrics.port }}/metrics"
+    kubectl port-forward --namespace {{ .Release.Namespace }} {{ template "rabbitmq.fullname" . }}-0 {{ .Values.metrics.port }}:{{ .Values.metrics.port }}
+
+Then, open the URL obtained in a browser.
+
+{{- end }}
+
+{{- include "rabbitmq.validateValues" . -}}
+
+{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
+
+WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
++info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
+
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/_helpers.tpl
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/_helpers.tpl
@@ -1,0 +1,258 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rabbitmq.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rabbitmq.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rabbitmq.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the proper RabbitMQ plugin list
+*/}}
+{{- define "rabbitmq.plugins" -}}
+{{- $plugins := .Values.rabbitmq.plugins | replace " " ", " -}}
+{{- if .Values.rabbitmq.extraPlugins -}}
+{{- $extraPlugins := .Values.rabbitmq.extraPlugins | replace " " ", " -}}
+{{- printf "[%s, %s]." $plugins $extraPlugins | indent 4 -}}
+{{- else -}}
+{{- printf "[%s]." $plugins | indent 4 -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper RabbitMQ image name
+*/}}
+{{- define "rabbitmq.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper metrics image name
+*/}}
+{{- define "rabbitmq.metrics.image" -}}
+{{- $registryName := .Values.metrics.image.registry -}}
+{{- $repositoryName := .Values.metrics.image.repository -}}
+{{- $tag := .Values.metrics.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the password secret.
+*/}}
+{{- define "rabbitmq.secretPasswordName" -}}
+    {{- if .Values.rabbitmq.existingPasswordSecret -}}
+        {{- printf "%s" .Values.rabbitmq.existingPasswordSecret -}}
+    {{- else -}}
+        {{- printf "%s" (include "rabbitmq.fullname" .) -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Get the erlang secret.
+*/}}
+{{- define "rabbitmq.secretErlangName" -}}
+    {{- if .Values.rabbitmq.existingErlangSecret -}}
+        {{- printf "%s" .Values.rabbitmq.existingErlangSecret -}}
+    {{- else -}}
+        {{- printf "%s" (include "rabbitmq.fullname" .) -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "rabbitmq.imagePullSecrets" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Also, we can not use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets .Values.volumePermissions.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.metrics.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.volumePermissions.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- else if or .Values.image.pullSecrets .Values.metrics.image.pullSecrets .Values.volumePermissions.image.pullSecrets }}
+imagePullSecrets:
+{{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.metrics.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- range .Values.volumePermissions.image.pullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper image name (for the init container volume-permissions image)
+*/}}
+{{- define "rabbitmq.volumePermissions.image" -}}
+{{- $registryName := .Values.volumePermissions.image.registry -}}
+{{- $repositoryName := .Values.volumePermissions.image.repository -}}
+{{- $tag := .Values.volumePermissions.image.tag | toString -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
+Also, we can't use a single if because lazy evaluation is not an option
+*/}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
+    {{- else -}}
+        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return  the proper Storage Class
+*/}}
+{{- define "rabbitmq.storageClass" -}}
+{{/*
+Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
+but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+*/}}
+{{- if .Values.global -}}
+    {{- if .Values.global.storageClass -}}
+        {{- if (eq "-" .Values.global.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+        {{- end -}}
+    {{- else -}}
+        {{- if .Values.persistence.storageClass -}}
+              {{- if (eq "-" .Values.persistence.storageClass) -}}
+                  {{- printf "storageClassName: \"\"" -}}
+              {{- else }}
+                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
+              {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- else -}}
+    {{- if .Values.persistence.storageClass -}}
+        {{- if (eq "-" .Values.persistence.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "rabbitmq.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "rabbitmq.validateValues.ldap" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of rabbitmq - LDAP support
+*/}}
+{{- define "rabbitmq.validateValues.ldap" -}}
+{{- if .Values.ldap.enabled }}
+{{- if not (and .Values.ldap.server .Values.ldap.port .Values.ldap.user_dn_pattern) }}
+rabbitmq: LDAP
+    Invalid LDAP configuration. When enabling LDAP support, the parameters "ldap.server",
+    "ldap.port", and "ldap. user_dn_pattern" are mandatory. Please provide them:
+
+    $ helm install {{ .Release.Name }} bitnami/rabbitmq \
+      --set ldap.enabled=true \
+      --set ldap.server="lmy-ldap-server" \
+      --set ldap.port="389" \
+      --set user_dn_pattern="cn=${username},dc=example,dc=org"
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "rabbitmq.tplValue" (dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "rabbitmq.tplValue" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/certs.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/certs.yaml
@@ -1,0 +1,19 @@
+{{- if and (not .Values.rabbitmq.tls.existingSecret) ( .Values.rabbitmq.tls.enabled) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}-certs
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: kubernetes.io/tls
+data:
+  ca.crt:
+    {{ required "A valid .Values.rabbitmq.tls.caCertificate entry required!" .Values.rabbitmq.tls.caCertificate | b64enc | quote }}
+  tls.crt:
+    {{ required "A valid .Values.rabbitmq.tls.serverCertificate entry required!" .Values.rabbitmq.tls.serverCertificate| b64enc | quote }}
+  tls.key:
+    {{ required "A valid .Values.rabbitmq.tls.serverKey entry required!" .Values.rabbitmq.tls.serverKey | b64enc | quote }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/configuration.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/configuration.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}-config
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  enabled_plugins: |-
+{{ template "rabbitmq.plugins" . }}
+  rabbitmq.conf: |-
+    ##username and password
+    default_user={{.Values.rabbitmq.username}}
+    default_pass=CHANGEME
+{{ .Values.rabbitmq.configuration | indent 4 }}
+{{ .Values.rabbitmq.extraConfiguration | indent 4 }}
+{{- if .Values.rabbitmq.tls.enabled }}
+    ssl_options.verify={{ .Values.rabbitmq.tls.sslOptionsVerify }}
+    listeners.ssl.default={{ .Values.service.tlsPort }}
+    ssl_options.fail_if_no_peer_cert={{ .Values.rabbitmq.tls.failIfNoPeerCert }}
+    ssl_options.cacertfile = /opt/bitnami/rabbitmq/certs/ca_certificate.pem
+    ssl_options.certfile = /opt/bitnami/rabbitmq/certs/server_certificate.pem
+    ssl_options.keyfile = /opt/bitnami/rabbitmq/certs/server_key.pem
+{{- end }}
+{{- if .Values.ldap.enabled }}
+    auth_backends.1 = rabbit_auth_backend_ldap
+    auth_backends.2 = internal
+    auth_ldap.servers.1  = {{ .Values.ldap.server }}
+    auth_ldap.port = {{ .Values.ldap.port }}
+    auth_ldap.user_dn_pattern = {{ .Values.ldap.user_dn_pattern  }}
+{{- if .Values.ldap.tls.enabled }}
+    auth_ldap.use_ssl = true
+{{- end }}
+{{- end }}
+
+{{ if .Values.rabbitmq.advancedConfiguration}}
+  advanced.config: |-
+{{ .Values.rabbitmq.advancedConfiguration | indent 4 }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/healthchecks.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/healthchecks.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}-healthchecks
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  rabbitmq-health-check: |-
+    #!/bin/sh
+    START_FLAG=/opt/bitnami/rabbitmq/var/lib/rabbitmq/.start
+    if [ -f ${START_FLAG} ]; then
+        rabbitmqctl node_health_check
+        RESULT=$?
+        if [ $RESULT -ne 0 ]; then
+          rabbitmqctl status
+          exit $?
+        fi
+        rm -f ${START_FLAG}
+        exit ${RESULT}
+    fi
+    rabbitmq-api-check $1 $2
+  rabbitmq-api-check: |-
+    #!/bin/sh
+    set -e
+    URL=$1
+    EXPECTED=$2
+    ACTUAL=$(curl --silent --show-error --fail "${URL}")
+    echo "${ACTUAL}"
+    test "${EXPECTED}" = "${ACTUAL}"

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/ingress.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "{{ template "rabbitmq.fullname" . }}"
+  labels:
+    app: "{{ template "rabbitmq.name" . }}"
+    chart: "{{ template "rabbitmq.chart" .  }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  annotations:
+    {{- if .Values.ingress.tls }}
+    ingress.kubernetes.io/secure-backends: "true"
+    {{- end }}
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+  {{- if .Values.ingress.hostName }}
+  - host: {{ .Values.ingress.hostName }}
+    http:
+  {{- else }}
+  - http:
+  {{- end }}
+      paths:
+        - path: {{ .Values.ingress.path }}
+          backend:
+            serviceName: {{ template "rabbitmq.fullname" . }}
+            servicePort: {{ .Values.service.managerPort }}
+{{- if .Values.ingress.tls }}
+  tls:
+  - hosts:
+    {{- if  .Values.ingress.hostName }}
+    - {{ .Values.ingress.hostName }}
+    secretName: {{  .Values.ingress.tlsSecret }}
+    {{- else}}
+    - secretName: {{  .Values.ingress.tlsSecret }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/networkpolicy.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/networkpolicy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "rabbitmq.name" . }}
+      release: {{ .Release.Name | quote }}
+  ingress:
+    # Allow inbound connections
+
+    - ports:
+        - port: 4369  # EPMD
+        - port: {{ .Values.service.port }}
+        - port: {{ .Values.service.tlsPort }}
+        - port: {{ .Values.service.distPort }}
+        - port: {{ .Values.service.managerPort }}
+
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "rabbitmq.fullname" . }}-client: "true"
+        {{- with .Values.networkPolicy.additionalRules }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+      {{- end }}
+
+    # Allow prometheus scrapes
+    - ports:
+        - port: {{ .Values.metrics.port }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/pdb.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "rabbitmq.name" . }}
+      release: "{{ .Release.Name }}"
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end -}}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/prometheusrule.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}
+{{- with .Values.metrics.prometheusRule.namespace }}
+  namespace: {{ . }}
+{{- end }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Values.metrics.prometheusRule.additionalLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.metrics.prometheusRule.rules }}
+  groups:
+    - name: {{ template "rabbitmq.name" $ }}
+      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/role.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/role.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbacEnabled }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}-endpoint-reader
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get"]
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/rolebinding.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbacEnabled }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}-endpoint-reader
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ template "rabbitmq.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "rabbitmq.fullname" . }}-endpoint-reader
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/secrets.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/secrets.yaml
@@ -1,0 +1,38 @@
+{{- if or (not .Values.rabbitmq.existingErlangSecret) (not .Values.rabbitmq.existingPasswordSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  {{ if not .Values.rabbitmq.existingPasswordSecret }}{{ if .Values.rabbitmq.password }}
+  rabbitmq-password: {{ .Values.rabbitmq.password | b64enc | quote }}
+  {{ else }}
+  rabbitmq-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}{{ end }}
+  {{ if not .Values.rabbitmq.existingErlangSecret }}{{ if .Values.rabbitmq.erlangCookie }}
+  rabbitmq-erlang-cookie: {{ .Values.rabbitmq.erlangCookie | b64enc | quote }}
+  {{ else }}
+  rabbitmq-erlang-cookie: {{ randAlphaNum 32 | b64enc | quote }}
+  {{ end }}{{ end }}
+{{- end }}
+{{- range $key, $value := .Values.extraSecrets }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $key }}
+  labels:
+    app: {{ template "rabbitmq.name" $ }}
+    chart: {{ template "rabbitmq.chart" $ }}
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+type: Opaque
+stringData:
+{{ $value | toYaml | nindent 2 }}
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/serviceaccount.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.rbacEnabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/servicemonitor.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/servicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}
+  {{- if .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    heritage: "{{ .Release.Service }}"
+    release: {{ if .Values.metrics.serviceMonitor.release }}"{{ .Values.metrics.serviceMonitor.release }}"{{ else }}"{{ .Release.Name }}"{{ end }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.metrics.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+  - port: metrics
+    interval: {{ .Values.metrics.serviceMonitor.interval }}
+    {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+    {{- if .Values.metrics.serviceMonitor.relabellings }}
+    metricRelabelings:
+{{ toYaml .Values.metrics.serviceMonitor.relabellings | indent 6 }}
+    {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "rabbitmq.name" . }}
+      release: "{{ .Release.Name }}"
+{{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/statefulset.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/statefulset.yaml
@@ -1,0 +1,372 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  serviceName: {{ template "rabbitmq.fullname" . }}-headless
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  replicas: {{ .Values.replicas }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+    {{- if (eq "Recreate" .Values.updateStrategy.type) }}
+    rollingUpdate: null
+    {{- end }}
+  selector:
+    matchLabels:
+      app: {{ template "rabbitmq.name" . }}
+      release: "{{ .Release.Name }}"
+  template:
+    metadata:
+      labels:
+        app: {{ template "rabbitmq.name" . }}
+        release: "{{ .Release.Name }}"
+        chart: {{ template "rabbitmq.chart" .  }}
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+      {{- end }}
+      annotations:
+        {{- if or (not .Values.rabbitmq.existingErlangSecret) (not .Values.rabbitmq.existingPasswordSecret) }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- end }}
+      {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
+    spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
+{{- include "rabbitmq.imagePullSecrets" . | indent 6 }}
+      {{- if .Values.rbacEnabled}}
+      serviceAccountName: {{ template "rabbitmq.fullname" . }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "rabbitmq.tplValue" (dict "value" .Values.affinity "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 10
+      {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled .Values.securityContext.enabled }}
+      initContainers:
+      - name: volume-permissions
+        image: "{{ template "rabbitmq.volumePermissions.image" . }}"
+        imagePullPolicy: {{ default "" .Values.volumePermissions.image.pullPolicy | quote }}
+        command: ["/bin/chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }}", "{{ .Values.persistence.path }}"]
+        securityContext:
+          runAsUser: 0
+        resources:
+{{ toYaml .Values.volumePermissions.resources | indent 10 }}
+        volumeMounts:
+        - name: data
+          mountPath: "{{ .Values.persistence.path }}"
+      {{- end }}
+      containers:
+      - name: rabbitmq
+        image: {{ template "rabbitmq.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        command:
+         - bash
+         - -ec
+         - |
+            mkdir -p /opt/bitnami/rabbitmq/.rabbitmq/
+            mkdir -p /opt/bitnami/rabbitmq/etc/rabbitmq/
+            touch /opt/bitnami/rabbitmq/var/lib/rabbitmq/.start
+            #persist the erlang cookie in both places for server and cli tools
+            echo $RABBITMQ_ERL_COOKIE > /opt/bitnami/rabbitmq/var/lib/rabbitmq/.erlang.cookie
+            cp /opt/bitnami/rabbitmq/var/lib/rabbitmq/.erlang.cookie /opt/bitnami/rabbitmq/.rabbitmq/
+            #change permission so only the user has access to the cookie file
+            chmod 600 /opt/bitnami/rabbitmq/.rabbitmq/.erlang.cookie /opt/bitnami/rabbitmq/var/lib/rabbitmq/.erlang.cookie
+            #copy the mounted configuration to both places
+            cp  /opt/bitnami/rabbitmq/conf/* /opt/bitnami/rabbitmq/etc/rabbitmq
+            # Apply resources limits
+            {{- if .Values.rabbitmq.setUlimitNofiles }}
+            ulimit -n "${RABBITMQ_ULIMIT_NOFILES}"
+            {{- end }}
+            #replace the default password that is generated
+            sed -i "/CHANGEME/cdefault_pass=${RABBITMQ_PASSWORD//\\/\\\\}" /opt/bitnami/rabbitmq/etc/rabbitmq/rabbitmq.conf
+            {{- if and .Values.persistence.enabled .Values.forceBoot.enabled }}
+            if [ -d "{{ .Values.persistence.path }}/mnesia/${RABBITMQ_NODENAME}" ]; then rabbitmqctl force_boot; fi
+            {{- end }}
+            exec rabbitmq-server
+        {{- if .Values.resources }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        {{- end }}
+        volumeMounts:
+          - name: config-volume
+            mountPath: /opt/bitnami/rabbitmq/conf
+          - name: healthchecks
+            mountPath: /usr/local/sbin/rabbitmq-api-check
+            subPath: rabbitmq-api-check
+          - name: healthchecks
+            mountPath: /usr/local/sbin/rabbitmq-health-check
+            subPath: rabbitmq-health-check
+          {{- if .Values.rabbitmq.tls.enabled }}
+          - name: {{ template "rabbitmq.fullname" . }}-certs
+            mountPath: /opt/bitnami/rabbitmq/certs
+          {{- end }}
+          - name: data
+            mountPath: "{{ .Values.persistence.path }}"
+          {{- if .Values.rabbitmq.loadDefinition.enabled }}
+          - name: load-definition-volume
+            mountPath: /app
+            readOnly: true
+          {{- end }}
+        ports:
+        - name: epmd
+          containerPort: 4369
+        - name: amqp
+          containerPort: {{ .Values.service.port }}
+        {{- if .Values.rabbitmq.tls.enabled }}
+        - name: amqp-ssl
+          containerPort: {{ .Values.service.tlsPort }}
+        {{- end }}
+        - name: dist
+          containerPort: {{ .Values.service.distPort }}
+        - name: stats
+          containerPort: {{ .Values.service.managerPort }}
+{{- if .Values.service.extraContainerPorts }}
+{{ toYaml .Values.service.extraContainerPorts | indent 8 }}
+{{- end }}
+        {{- if .Values.livenessProbe.enabled }}
+        livenessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - rabbitmq-api-check "http://{{ .Values.rabbitmq.username }}:$RABBITMQ_PASSWORD@127.0.0.1:{{ .Values.service.managerPort }}/api/healthchecks/node" '{"status":"ok"}'
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.readinessProbe.enabled }}
+        readinessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - rabbitmq-health-check "http://{{ .Values.rabbitmq.username }}:$RABBITMQ_PASSWORD@127.0.0.1:{{ .Values.service.managerPort }}/api/healthchecks/node" '{"status":"ok"}'
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+        {{- end }}
+        {{- if and (gt (.Values.replicas | int) 1) ( eq .Values.rabbitmq.clustering.rebalance true) }}
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - until rabbitmqctl cluster_status >/dev/null; do echo Waiting for
+                cluster readiness...; sleep 5 ; done; rabbitmq-queues rebalance "all"
+        {{- end }}
+        env:
+          - name: BITNAMI_DEBUG
+            value: {{ ternary "true" "false" .Values.image.debug | quote }}
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: K8S_SERVICE_NAME
+            value: "{{ template "rabbitmq.fullname" . }}-headless"
+          - name: K8S_ADDRESS_TYPE
+            value: {{ .Values.rabbitmq.clustering.address_type }}
+          {{- if (eq "hostname" .Values.rabbitmq.clustering.address_type) }}
+          - name: RABBITMQ_NODENAME
+            value: "rabbit@$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.rabbitmq.clustering.k8s_domain }}"
+          - name: K8S_HOSTNAME_SUFFIX
+            value: ".$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.rabbitmq.clustering.k8s_domain }}"
+          {{- else }}
+          - name: RABBITMQ_NODENAME
+            {{- if .Values.rabbitmq.rabbitmqClusterNodeName }}
+            value: {{ .Values.rabbitmq.rabbitmqClusterNodeName | quote }}
+            {{- else }}
+            value: "rabbit@$(MY_POD_NAME)"
+            {{- end }}
+          {{- end }}
+          {{- if .Values.ldap.enabled }}
+          - name: RABBITMQ_LDAP_ENABLE
+            value: "yes"
+          - name: RABBITMQ_LDAP_TLS
+            value: {{ ternary "yes" "no" .Values.ldap.tls.enabled | quote }}
+          - name: RABBITMQ_LDAP_SERVER
+            value: {{ .Values.ldap.server }}
+          - name: RABBITMQ_LDAP_SERVER_PORT
+            value: {{ .Values.ldap.port | quote }}
+          - name: RABBITMQ_LDAP_USER_DN_PATTERN
+            value: {{ .Values.ldap.user_dn_pattern }}
+          {{- end }}
+          - name: RABBITMQ_LOGS
+            value: {{ .Values.rabbitmq.logs | quote }}
+          - name: RABBITMQ_ULIMIT_NOFILES
+            value: {{ .Values.rabbitmq.ulimitNofiles | quote }}
+          {{- if and .Values.rabbitmq.maxAvailableSchedulers }}
+          - name: RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS
+            value: {{ printf "+S %s:%s" (toString .Values.rabbitmq.maxAvailableSchedulers) (toString .Values.rabbitmq.onlineSchedulers) -}}
+          {{- end }}
+          - name: RABBITMQ_USE_LONGNAME
+            value: "true"
+          - name: RABBITMQ_ERL_COOKIE
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "rabbitmq.secretErlangName" . }}
+                key: rabbitmq-erlang-cookie
+          - name: RABBITMQ_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "rabbitmq.secretPasswordName" . }}
+                key: rabbitmq-password
+          {{- range $key, $value := .Values.rabbitmq.env }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+{{- if .Values.metrics.enabled }}
+      - name: metrics
+        image: {{ template "rabbitmq.metrics.image" . }}
+        imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+        env:
+        - name: RABBIT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "rabbitmq.secretPasswordName" . }}
+              key: rabbitmq-password
+        - name: RABBIT_URL
+          value: "http://{{ .Values.metrics.rabbitmqAddress }}:{{ .Values.service.managerPort }}"
+        - name: RABBIT_USER
+          value: {{ .Values.rabbitmq.username }}
+        - name: PUBLISH_PORT
+          value: "{{ .Values.metrics.port }}"
+        {{ if .Values.metrics.capabilities }}
+        - name: RABBIT_CAPABILITIES
+          value: "{{ .Values.metrics.capabilities }}"
+        {{- end }}
+        {{- range $key, $value := .Values.metrics.env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.metrics.port }}
+        {{- if .Values.metrics.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
+          successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.metrics.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
+          successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
+        {{- end }}
+        resources:
+{{ toYaml .Values.metrics.resources | indent 10 }}
+{{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        {{- if .Values.securityContext.extra }}
+        {{- toYaml .Values.securityContext.extra | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      volumes:
+        {{- if .Values.rabbitmq.tls.enabled }}
+        - name: {{ template "rabbitmq.fullname" . }}-certs
+          secret:
+            secretName: {{ if .Values.rabbitmq.tls.existingSecret }}{{ .Values.rabbitmq.tls.existingSecret }}{{- else }}{{ template "rabbitmq.fullname" . }}-certs{{- end }}
+            items:
+            - key: ca.crt
+              path: ca_certificate.pem
+            - key: tls.crt
+              path: server_certificate.pem
+            - key: tls.key
+              path: server_key.pem
+        {{- end }}
+        - name: config-volume
+          configMap:
+            name: {{ template "rabbitmq.fullname" . }}-config
+            items:
+            - key: rabbitmq.conf
+              path: rabbitmq.conf
+        {{- if .Values.rabbitmq.advancedConfiguration}}
+            - key: advanced.config
+              path: advanced.config
+        {{- end }}
+            - key: enabled_plugins
+              path: enabled_plugins
+        - name: healthchecks
+          configMap:
+            name: {{ template "rabbitmq.fullname" . }}-healthchecks
+            items:
+            - key: rabbitmq-health-check
+              path: rabbitmq-health-check
+              mode: 111
+            - key: rabbitmq-api-check
+              path: rabbitmq-api-check
+              mode: 111
+        {{- if .Values.rabbitmq.loadDefinition.enabled }}
+        - name: load-definition-volume
+          secret:
+            secretName: {{ .Values.rabbitmq.loadDefinition.secretName | quote }}
+        {{- end }}
+      {{- if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+      {{- else if .Values.persistence.existingClaim }}
+        - name: data
+          persistentVolumeClaim:
+          {{- with .Values.persistence.existingClaim }}
+            claimName: {{ tpl . $ }}
+          {{- end }}
+  {{- else }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          app: {{ template "rabbitmq.name" . }}
+          release: "{{ .Release.Name }}"
+          heritage: "{{ .Release.Service }}"
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode | quote }}
+        resources:
+            requests:
+              storage: {{ .Values.persistence.size | quote }}
+        {{ include "rabbitmq.storageClass" . }}
+  {{- end }}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/svc-headless.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/svc-headless.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}-headless
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  clusterIP: None
+  ports:
+  - name: epmd
+    port: 4369
+    targetPort: epmd
+  - name: amqp
+    port: {{ .Values.service.port }}
+    targetPort: amqp
+{{- if .Values.rabbitmq.tls.enabled }}
+  - name: amqp-tls
+    port: {{ .Values.service.tlsPort }}
+    targetPort: amqp-tls
+{{- end }}
+  - name: dist
+    port: {{ .Values.service.distPort }}
+    targetPort: dist
+  - name: stats
+    port: {{ .Values.service.managerPort }}
+    targetPort: stats
+  selector:
+    app: {{ template "rabbitmq.name" . }}
+    release: "{{ .Release.Name }}"

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/svc.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/templates/svc.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "rabbitmq.fullname" . }}
+  labels:
+    app: {{ template "rabbitmq.name" . }}
+    chart: {{ template "rabbitmq.chart" .  }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- if or .Values.service.annotations .Values.metrics.enabled }}
+  annotations:
+{{- end }}
+{{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.metrics.enabled }}
+{{ toYaml .Values.metrics.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+{{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{ with .Values.service.loadBalancerSourceRanges }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+  - name: epmd
+    port: 4369
+    targetPort: epmd
+    {{- if (eq .Values.service.type "ClusterIP") }}
+    nodePort: null
+    {{- end }}
+  - name: amqp
+    port: {{ .Values.service.port }}
+    targetPort: amqp
+    {{- if (eq .Values.service.type "ClusterIP") }}
+    nodePort: null
+    {{- else if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
+  {{- if .Values.rabbitmq.tls.enabled }}
+  - name: amqp-ssl
+    port: {{ .Values.service.tlsPort }}
+    targetPort: amqp-ssl
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodeTlsPort))) }}
+    nodePort: {{ .Values.service.nodeTlsPort }}
+    {{- end }}
+  {{- end }}
+  - name: dist
+    port: {{ .Values.service.distPort }}
+    targetPort: dist
+    {{- if (eq .Values.service.type "ClusterIP") }}
+    nodePort: null
+    {{- end }}
+  - name: stats
+    port: {{ .Values.service.managerPort }}
+    targetPort: stats
+    {{- if (eq .Values.service.type "ClusterIP") }}
+    nodePort: null
+    {{- end }}
+{{- if .Values.metrics.enabled }}
+  - name: metrics
+    port: {{ .Values.metrics.port }}
+    targetPort: metrics
+    {{- if (eq .Values.service.type "ClusterIP") }}
+    nodePort: null
+    {{- end }}
+{{- end }}
+{{- if .Values.service.extraPorts }}
+{{ toYaml .Values.service.extraPorts | indent 2 }}
+{{- end }}
+  selector:
+    app: {{ template "rabbitmq.name" . }}
+    release: "{{ .Release.Name }}"

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/values-production.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/values-production.yaml
@@ -1,0 +1,574 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+##
+# global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+#   storageClass: myStorageClass
+
+## Bitnami RabbitMQ image version
+## ref: https://hub.docker.com/r/bitnami/rabbitmq/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/rabbitmq
+  tag: 3.8.2-debian-10-r41
+
+  ## set to true if you would like to see extra information on logs
+  ## it turns BASH and NAMI debugging in minideb
+  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
+  debug: false
+
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## String to partially override rabbitmq.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override rabbitmq.fullname template
+##
+# fullnameOverride:
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+## does your cluster have rbac enabled? assume yes by default
+rbacEnabled: true
+
+## RabbitMQ should be initialized one by one when building cluster for the first time.
+## Therefore, the default value of podManagementPolicy is 'OrderedReady'
+## Once the RabbitMQ participates in the cluster, it waits for a response from another
+## RabbitMQ in the same cluster at reboot, except the last RabbitMQ of the same cluster.
+## If the cluster exits gracefully, you do not need to change the podManagementPolicy
+## because the first RabbitMQ of the statefulset always will be last of the cluster.
+## However if the last RabbitMQ of the cluster is not the first RabbitMQ due to a failure,
+## you must change podManagementPolicy to 'Parallel'.
+## ref : https://www.rabbitmq.com/clustering.html#restarting
+##
+podManagementPolicy: OrderedReady
+
+## section of specific values for rabbitmq
+rabbitmq:
+  ## RabbitMQ application username
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  username: user
+
+  ## RabbitMQ application password
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  # password:
+  # existingPasswordSecret: name-of-existing-secret
+
+  ## Erlang cookie to determine whether different nodes are allowed to communicate with each other
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  # erlangCookie:
+  # existingErlangSecret: name-of-existing-secret
+
+  ## Node name to cluster with. e.g.: `clusternode@hostname`
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  # rabbitmqClusterNodeName:
+
+  ## Value for the RABBITMQ_LOGS environment variable
+  ## ref: https://www.rabbitmq.com/logging.html#log-file-location
+  ##
+  logs: '-'
+
+  ## RabbitMQ Max File Descriptors
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ## ref: https://www.rabbitmq.com/install-debian.html#kernel-resource-limits
+  ##
+  setUlimitNofiles: true
+  ulimitNofiles: '65536'
+
+  ## RabbitMQ maximum available scheduler threads and online scheduler threads
+  ## ref: https://hamidreza-s.github.io/erlang/scheduling/real-time/preemptive/migration/2016/02/09/erlang-scheduler-details.html#scheduler-threads
+  ##
+  maxAvailableSchedulers: 2
+  onlineSchedulers: 1
+
+  ## Plugins to enable
+  plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
+
+  ## Extra plugins to enable
+  ## Use this instead of `plugins` to add new plugins
+  extraPlugins: "rabbitmq_auth_backend_ldap"
+
+  ## Clustering settings
+  clustering:
+    address_type: hostname
+    k8s_domain: cluster.local
+    ## Rebalance master for queues in cluster when new replica is created
+    ## ref: https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
+    rebalance: false
+
+  loadDefinition:
+    enabled: false
+    secretName: load-definition
+
+  ## environment variables to configure rabbitmq
+  ## ref: https://www.rabbitmq.com/configure.html#customise-environment
+  env: {}
+
+  ## Configuration file content: required cluster configuration
+  ## Do not override unless you know what you are doing. To add more configuration, use `extraConfiguration` of `advancedConfiguration` instead
+  configuration: |-
+    ## Clustering
+    cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
+    cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
+    cluster_formation.node_cleanup.interval = 10
+    cluster_formation.node_cleanup.only_log_warning = true
+    cluster_partition_handling = autoheal
+    # queue master locator
+    queue_master_locator=min-masters
+    # enable guest user
+    loopback_users.guest = false
+
+  ## Configuration file content: extra configuration
+  ## Use this instead of `configuration` to add more configuration
+  extraConfiguration: |-
+    #disk_free_limit.absolute = 50MB
+    #management.load_definitions = /app/load_definition.json
+
+  ## Configuration file content: advanced configuration
+  ## Use this as additional configuraton in classic config format (Erlang term configuration format)
+  ## If you set LDAP with TLS/SSL enabled and you are using self-signed certificates, uncomment these lines.
+  ## advancedConfiguration: |-
+  ##   [{
+  ##     rabbitmq_auth_backend_ldap,
+  ##     [{
+  ##         ssl_options,
+  ##         [{
+  ##             verify, verify_none
+  ##         }, {
+  ##             fail_if_no_peer_cert,
+  ##             false
+  ##         }]
+  ##     ]}
+  ##   }].
+  ##
+  advancedConfiguration: |-
+
+  ## Enable encryption to rabbitmq
+  ## ref: https://www.rabbitmq.com/ssl.html
+  ##
+  tls:
+    enabled: false
+    failIfNoPeerCert: true
+    sslOptionsVerify: verify_peer
+    caCertificate: |-
+    serverCertificate: |-
+    serverKey: |-
+    # existingSecret: name-of-existing-secret-to-rabbitmq
+
+## LDAP configuration
+##
+ldap:
+  enabled: false
+  server: ""
+  port: "389"
+  user_dn_pattern: cn=${username},dc=example,dc=org
+  tls:
+    # If you enabled TLS/SSL you can set advaced options using the advancedConfiguration parameter.
+    enabled: false
+
+## Kubernetes service type
+service:
+  type: ClusterIP
+  ## Node port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  # nodePort: 30672
+
+  ## Set the LoadBalancerIP
+  ##
+  # loadBalancerIP:
+
+  ## Node port Tls
+  ##
+  # nodeTlsPort: 30671
+
+  ## Amqp port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  port: 5672
+
+  ## Amqp Tls port
+  ##
+  tlsPort: 5671
+
+  ## Dist port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  distPort: 25672
+
+  ## RabbitMQ Manager port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  managerPort: 15672
+
+  ## Service annotations
+  annotations: {}
+    # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+
+  ## Load Balancer sources
+  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ##
+  # loadBalancerSourceRanges:
+  # - 10.10.10.0/24
+
+  ## Extra ports to expose
+  # extraPorts:
+
+  ## Extra ports to be included in container spec, primarily informational
+  # extraContainerPorts:
+
+# Additional pod labels to apply
+podLabels: {}
+
+## Pod Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+  extra: {}
+
+persistence:
+  ## this enables PVC templates that will create one per pod
+  enabled: true
+
+  ## rabbitmq data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+
+  ## Existing PersistentVolumeClaims
+  ## The value is evaluated as a template
+  ## So, for example, the name can depend on .Release or .Chart
+  # existingClaim: ""
+
+  # If you change this value, you might have to adjust `rabbitmq.diskFreeLimit` as well.
+  size: 8Gi
+
+  # persistence directory, maps to the rabbitmq data directory
+  path: /opt/bitnami/rabbitmq/var/lib/rabbitmq
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 100m
+
+networkPolicy:
+  ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the port RabbitMQ is listening
+  ## on. When true, RabbitMQ will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+
+  ## Additional NetworkPolicy Ingress "from" rules to set. Note that all rules are OR-ed.
+  ##
+  # additionalRules:
+  #  - matchLabels:
+  #    - role: frontend
+  #  - matchExpressions:
+  #    - key: role
+  #      operator: In
+  #      values:
+  #        - frontend
+
+## Replica count, set to 3 to provide a default available cluster
+replicas: 3
+
+## Pod priority
+## https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# priorityClassName: ""
+
+## updateStrategy for RabbitMQ statefulset
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+updateStrategy:
+  type: RollingUpdate
+
+## Node labels and tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+nodeSelector:
+  beta.kubernetes.io/arch: amd64
+tolerations: []
+affinity: {}
+
+## affinity: |
+##   podAntiAffinity:
+##     requiredDuringSchedulingIgnoredDuringExecution:
+##       - labelSelector:
+##           matchLabels:
+##             app: {{ template "rabbitmq.name" . }}
+##             release: {{ .Release.Name | quote }}
+##         topologyKey: kubernetes.io/hostname
+##     preferredDuringSchedulingIgnoredDuringExecution:
+##       - weight: 100
+##         podAffinityTerm:
+##           labelSelector:
+##             matchLabels:
+##               app:  {{ template "rabbitmq.name" . }}
+##               release: {{ .Release.Name | quote }}
+##           topologyKey: failure-domain.beta.kubernetes.io/zone
+
+## annotations for rabbitmq pods
+podAnnotations: {}
+
+## Configure the podDisruptionBudget
+podDisruptionBudget: {}
+# maxUnavailable: 1
+# minAvailable: 1
+
+## Configure the ingress resource that allows you to access the
+## Wordpress installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  enabled: false
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  ## hostName: foo.bar.com
+  path: /
+
+  ## Set this to true in order to enable TLS on the ingress record
+  ## A side effect of this will be that the backend wordpress service will be connected at port 443
+  tls: true
+
+  ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+  tlsSecret: myTlsSecret
+
+  ## Ingress annotations done as key:value pairs
+  ## If you're using kube-lego, you will want to add:
+  ## kubernetes.io/tls-acme: true
+  ##
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  annotations: {}
+  #  kubernetes.io/ingress.class: nginx
+  #  kubernetes.io/tls-acme: true
+
+## The following settings are to configure the frequency of the lifeness and readiness probes
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 120
+  timeoutSeconds: 20
+  periodSeconds: 30
+  failureThreshold: 6
+  successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 20
+  periodSeconds: 30
+  failureThreshold: 3
+  successThreshold: 1
+
+metrics:
+  enabled: true
+  image:
+    registry: docker.io
+    repository: bitnami/rabbitmq-exporter
+    tag: 0.29.0-debian-10-r38
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+  ## environment variables to configure rabbitmq_exporter
+  ## ref: https://github.com/kbudde/rabbitmq_exporter#configuration
+  env: {}
+  ## Metrics exporter port
+  port: 9419
+  ## Comma-separated list of extended scraping capabilities supported by the target RabbitMQ server
+  ## ref: https://github.com/kbudde/rabbitmq_exporter#extended-rabbitmq-capabilities
+  capabilities: "bert,no_sort"
+  resources: {}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9419"
+
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 15
+    timeoutSeconds: 5
+    periodSeconds: 30
+    failureThreshold: 6
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    timeoutSeconds: 5
+    periodSeconds: 30
+    failureThreshold: 3
+    successThreshold: 1
+
+  ## Prometheus Service Monitor
+  ## ref: https://github.com/coreos/prometheus-operator
+  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  serviceMonitor:
+    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    enabled: false
+    ## Specify the namespace in which the serviceMonitor resource will be created
+    # namespace: ""
+    ## Specify the interval at which metrics should be scraped
+    interval: 30s
+    ## Specify the timeout after which the scrape is ended
+    # scrapeTimeout: 30s
+    ## Specify Metric Relabellings to add to the scrape endpoint
+    # relabellings:
+    ## Specify honorLabels parameter to add the scrape endpoint
+    honorLabels: false
+    ## Specify the release for ServiceMonitor. Sometimes it should be custom for prometheus operator to work
+    # release: ""
+    ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    additionalLabels: {}
+
+  ## Custom PrometheusRule to be defined
+  ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
+  ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+  prometheusRule:
+    enabled: false
+    additionalLabels: {}
+    namespace: ""
+    rules: []
+      ## List of reules, used as template by Helm.
+      ## These are just examples rules inspired from https://awesome-prometheus-alerts.grep.to/rules.html
+      ## Please adapt them to your needs.
+      ## Make sure to constraint the rules to the current rabbitmq service.
+      ## Also make sure to escape what looks like helm template.
+      # - alert: RabbitmqDown
+      #   expr: rabbitmq_up{service="{{ template "rabbitmq.fullname" . }}"} == 0
+      #   for: 5m
+      #   labels:
+      #     severity: error
+      #   annotations:
+      #     summary: Rabbitmq down (instance {{ "{{ $labels.instance }}" }})
+      #     description: RabbitMQ node down
+
+      # - alert: ClusterDown
+      #   expr: |
+      #     sum(rabbitmq_running{service="{{ template "rabbitmq.fullname" . }}"})
+      #     < {{ .Values.replicas }}
+      #   for: 5m
+      #   labels:
+      #     severity: error
+      #   annotations:
+      #     summary: Cluster down (instance {{ "{{ $labels.instance }}" }})
+      #     description: |
+      #         Less than {{ .Values.replicas }} nodes running in RabbitMQ cluster
+      #         VALUE = {{ "{{ $value }}" }}
+
+      # - alert: ClusterPartition
+      #   expr: rabbitmq_partitions{service="{{ template "rabbitmq.fullname" . }}"} > 0
+      #   for: 5m
+      #   labels:
+      #     severity: error
+      #   annotations:
+      #     summary: Cluster partition (instance {{ "{{ $labels.instance }}" }})
+      #     description: |
+      #         Cluster partition
+      #         VALUE = {{ "{{ $value }}" }}
+
+      # - alert: OutOfMemory
+      #   expr: |
+      #     rabbitmq_node_mem_used{service="{{ template "rabbitmq.fullname" . }}"}
+      #     / rabbitmq_node_mem_limit{service="{{ template "rabbitmq.fullname" . }}"}
+      #     * 100 > 90
+      #   for: 5m
+      #   labels:
+      #     severity: warning
+      #   annotations:
+      #     summary: Out of memory (instance {{ "{{ $labels.instance }}" }})
+      #     description: |
+      #         Memory available for RabbmitMQ is low (< 10%)\n  VALUE = {{ "{{ $value }}" }}
+      #         LABELS: {{ "{{ $labels }}" }}
+
+      # - alert: TooManyConnections
+      #   expr: rabbitmq_connectionsTotal{service="{{ template "rabbitmq.fullname" . }}"} > 1000
+      #   for: 5m
+      #   labels:
+      #     severity: warning
+      #   annotations:
+      #     summary: Too many connections (instance {{ "{{ $labels.instance }}" }})
+      #     description: |
+      #         RabbitMQ instance has too many connections (> 1000)
+      #         VALUE = {{ "{{ $value }}" }}\n  LABELS: {{ "{{ $labels }}" }}
+
+##
+## Init containers parameters:
+## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
+##
+volumePermissions:
+  enabled: true
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+  resources: {}
+
+## forceBoot: executes 'rabbitmqctl force_boot' to force boot cluster shut down unexpectedly in an
+## unknown order.
+## ref: https://www.rabbitmq.com/rabbitmqctl.8.html#force_boot
+##
+forceBoot:
+  enabled: false
+
+## Optionally specify extra secrets to be created by the chart.
+## This can be useful when combined with load_definitions to automatically create the secret containing the definitions to be loaded.
+##
+extraSecrets: {}
+  # load-definition:
+  #   load_definition.json: |
+  #     {
+  #       ...
+  #     }

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/values.schema.json
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/values.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "rabbitmq": {
+      "type": "object",
+      "properties": {
+        "username": {
+          "type": "string",
+          "title": "RabbitMQ user",
+          "form": true
+        },
+        "password": {
+          "type": "string",
+          "title": "RabbitMQ password",
+          "form": true,
+          "description": "Defaults to a random 10-character alphanumeric string if not set"
+        },
+        "extraConfiguration": {
+          "type": "string",
+          "title": "Extra RabbitMQ Configuration",
+          "form": true,
+          "render": "textArea",
+          "description": "Extra configuration to be appended to RabbitMQ Configuration"
+        }
+      }
+    },
+    "replicas": {
+      "type": "integer",
+      "form": true,
+      "title": "Number of replicas",
+      "description": "Number of replicas to deploy"
+    },
+    "persistence": {
+      "type": "object",
+      "title": "Persistence configuration",
+      "form": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable persistence",
+          "description": "Enable persistence using Persistent Volume Claims"
+        },
+        "size": {
+          "type": "string",
+          "title": "Persistent Volume Size",
+          "form": true,
+          "render": "slider",
+          "sliderMin": 1,
+          "sliderMax": 100,
+          "sliderUnit": "Gi",
+          "hidden": {
+            "condition": false,
+            "value": "persistence.enabled"
+          }
+        }
+      }
+    },
+    "volumePermissions": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "form": true,
+          "title": "Enable Init Containers",
+          "description": "Use an init container to set required folder permissions on the data volume before mounting it in the final destination"
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "form": true,
+      "title": "Prometheus metrics details",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Create Prometheus metrics exporter",
+          "description": "Create a side-car container to expose Prometheus metrics",
+          "form": true
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Create Prometheus Operator ServiceMonitor",
+              "description": "Create a ServiceMonitor to track metrics using Prometheus Operator",
+              "form": true,
+              "hidden": {
+                "condition": false,
+                "value": "metrics.enabled"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/values.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/charts/rabbitmq/values.yaml
@@ -1,0 +1,555 @@
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry and imagePullSecrets
+##
+# global:
+#   imageRegistry: myRegistryName
+#   imagePullSecrets:
+#     - myRegistryKeySecretName
+#   storageClass: myStorageClass
+
+## Bitnami RabbitMQ image version
+## ref: https://hub.docker.com/r/bitnami/rabbitmq/tags/
+##
+image:
+  registry: docker.io
+  repository: bitnami/rabbitmq
+  tag: 3.8.2-debian-10-r41
+
+  ## set to true if you would like to see extra information on logs
+  ## it turns BASH and NAMI debugging in minideb
+  ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
+  debug: false
+
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistryKeySecretName
+
+## String to partially override rabbitmq.fullname template (will maintain the release name)
+##
+# nameOverride:
+
+## String to fully override rabbitmq.fullname template
+##
+# fullnameOverride:
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
+## does your cluster have rbac enabled? assume yes by default
+rbacEnabled: true
+
+## RabbitMQ should be initialized one by one when building cluster for the first time.
+## Therefore, the default value of podManagementPolicy is 'OrderedReady'
+## Once the RabbitMQ participates in the cluster, it waits for a response from another
+## RabbitMQ in the same cluster at reboot, except the last RabbitMQ of the same cluster.
+## If the cluster exits gracefully, you do not need to change the podManagementPolicy
+## because the first RabbitMQ of the statefulset always will be last of the cluster.
+## However if the last RabbitMQ of the cluster is not the first RabbitMQ due to a failure,
+## you must change podManagementPolicy to 'Parallel'.
+## ref : https://www.rabbitmq.com/clustering.html#restarting
+##
+podManagementPolicy: OrderedReady
+
+## section of specific values for rabbitmq
+rabbitmq:
+  ## RabbitMQ application username
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  username: user
+
+  ## RabbitMQ application password
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  # password:
+  # existingPasswordSecret: name-of-existing-secret
+
+  ## Erlang cookie to determine whether different nodes are allowed to communicate with each other
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  # erlangCookie:
+  # existingErlangSecret: name-of-existing-secret
+
+  ## Node name to cluster with. e.g.: `clusternode@hostname`
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  # rabbitmqClusterNodeName:
+
+  ## Value for the RABBITMQ_LOGS environment variable
+  ## ref: https://www.rabbitmq.com/logging.html#log-file-location
+  ##
+  logs: '-'
+
+  ## RabbitMQ Max File Descriptors
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ## ref: https://www.rabbitmq.com/install-debian.html#kernel-resource-limits
+  ##
+  setUlimitNofiles: true
+  ulimitNofiles: '65536'
+
+  ## RabbitMQ maximum available scheduler threads and online scheduler threads
+  ## ref: https://hamidreza-s.github.io/erlang/scheduling/real-time/preemptive/migration/2016/02/09/erlang-scheduler-details.html#scheduler-threads
+  ##
+  maxAvailableSchedulers: 2
+  onlineSchedulers: 1
+
+  ## Plugins to enable
+  plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
+
+  ## Extra plugins to enable
+  ## Use this instead of `plugins` to add new plugins
+  extraPlugins: "rabbitmq_auth_backend_ldap"
+
+  ## Clustering settings
+  clustering:
+    address_type: hostname
+    k8s_domain: cluster.local
+    ## Rebalance master for queues in cluster when new replica is created
+    ## ref: https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
+    rebalance: false
+
+  loadDefinition:
+    enabled: false
+    secretName: load-definition
+
+  ## environment variables to configure rabbitmq
+  ## ref: https://www.rabbitmq.com/configure.html#customise-environment
+  env: {}
+
+  ## Configuration file content: required cluster configuration
+  ## Do not override unless you know what you are doing. To add more configuration, use `extraConfiguration` of `advancedConfiguration` instead
+  configuration: |-
+    ## Clustering
+    cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_k8s
+    cluster_formation.k8s.host = kubernetes.default.svc.cluster.local
+    cluster_formation.node_cleanup.interval = 10
+    cluster_formation.node_cleanup.only_log_warning = true
+    cluster_partition_handling = autoheal
+    # queue master locator
+    queue_master_locator=min-masters
+    # enable guest user
+    loopback_users.guest = false
+
+  ## Configuration file content: extra configuration
+  ## Use this instead of `configuration` to add more configuration
+  extraConfiguration: |-
+    #disk_free_limit.absolute = 50MB
+    #management.load_definitions = /app/load_definition.json
+
+  ## Configuration file content: advanced configuration
+  ## Use this as additional configuraton in classic config format (Erlang term configuration format)
+  ##
+  ## If you set LDAP with TLS/SSL enabled and you are using self-signed certificates, uncomment these lines.
+  ## advancedConfiguration: |-
+  ##   [{
+  ##     rabbitmq_auth_backend_ldap,
+  ##     [{
+  ##         ssl_options,
+  ##         [{
+  ##             verify, verify_none
+  ##         }, {
+  ##             fail_if_no_peer_cert,
+  ##             false
+  ##         }]
+  ##     ]}
+  ##   }].
+  ##
+  advancedConfiguration: |-
+
+  ## Enable encryption to rabbitmq
+  ## ref: https://www.rabbitmq.com/ssl.html
+  ##
+  tls:
+    enabled: false
+    failIfNoPeerCert: true
+    sslOptionsVerify: verify_peer
+    caCertificate: |-
+    serverCertificate: |-
+    serverKey: |-
+    # existingSecret: name-of-existing-secret-to-rabbitmq
+
+## LDAP configuration
+##
+ldap:
+  enabled: false
+  server: ""
+  port: "389"
+  user_dn_pattern: cn=${username},dc=example,dc=org
+  tls:
+    # If you enabled TLS/SSL you can set advaced options using the advancedConfiguration parameter.
+    enabled: false
+
+## Kubernetes service type
+service:
+  type: ClusterIP
+  ## Node port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  # nodePort: 30672
+
+  ## Set the LoadBalancerIP
+  ##
+  # loadBalancerIP:
+
+  ## Node port Tls
+  ##
+  # nodeTlsPort: 30671
+
+  ## Amqp port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  port: 5672
+
+  ## Amqp Tls port
+  ##
+  tlsPort: 5671
+
+  ## Dist port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  distPort: 25672
+
+  ## RabbitMQ Manager port
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ##
+  managerPort: 15672
+
+  ## Service annotations
+  annotations: {}
+    # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+
+  ## Load Balancer sources
+  ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ##
+  # loadBalancerSourceRanges:
+  # - 10.10.10.0/24
+
+  ## Extra ports to expose
+  # extraPorts:
+
+  ## Extra ports to be included in container spec, primarily informational
+  # extraContainerPorts:
+
+# Additional pod labels to apply
+podLabels: {}
+
+## Pod Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+##
+securityContext:
+  enabled: true
+  fsGroup: 1001
+  runAsUser: 1001
+  extra: {}
+
+persistence:
+  ## this enables PVC templates that will create one per pod
+  enabled: true
+
+  ## rabbitmq data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+
+  ## Existing PersistentVolumeClaims
+  ## The value is evaluated as a template
+  ## So, for example, the name can depend on .Release or .Chart
+  # existingClaim: ""
+
+  # If you change this value, you might have to adjust `rabbitmq.diskFreeLimit` as well.
+  size: 8Gi
+
+  # persistence directory, maps to the rabbitmq data directory
+  path: /opt/bitnami/rabbitmq/var/lib/rabbitmq
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+
+networkPolicy:
+  ## Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  ##
+  enabled: false
+
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to the ports RabbitMQ is listening
+  ## on. When true, RabbitMQ will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+
+  ## Additional NetworkPolicy Ingress "from" rules to set. Note that all rules are OR-ed.
+  ##
+  # additionalRules:
+  #  - matchLabels:
+  #    - role: frontend
+  #  - matchExpressions:
+  #    - key: role
+  #      operator: In
+  #      values:
+  #        - frontend
+
+## Replica count, set to 1 to provide a default available cluster
+replicas: 1
+
+## Pod priority
+## https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# priorityClassName: ""
+
+## updateStrategy for RabbitMQ statefulset
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+updateStrategy:
+  type: RollingUpdate
+
+## Node labels and tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podDisruptionBudget: {}
+  # maxUnavailable: 1
+  # minAvailable: 1
+## annotations for rabbitmq pods
+podAnnotations: {}
+
+## Configure the ingress resource that allows you to access the
+## Wordpress installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+  ## Set to true to enable ingress record generation
+  enabled: false
+
+  ## The list of hostnames to be covered with this ingress record.
+  ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
+  ## hostName: foo.bar.com
+  path: /
+
+  ## Set this to true in order to enable TLS on the ingress record
+  ## A side effect of this will be that the backend wordpress service will be connected at port 443
+  tls: false
+
+  ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+  tlsSecret: myTlsSecret
+
+  ## Ingress annotations done as key:value pairs
+  ## If you're using kube-lego, you will want to add:
+  ## kubernetes.io/tls-acme: true
+  ##
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
+  annotations: {}
+  #  kubernetes.io/ingress.class: nginx
+  #  kubernetes.io/tls-acme: true
+
+## The following settings are to configure the frequency of the lifeness and readiness probes
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 120
+  timeoutSeconds: 20
+  periodSeconds: 30
+  failureThreshold: 6
+  successThreshold: 1
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 20
+  periodSeconds: 30
+  failureThreshold: 3
+  successThreshold: 1
+
+metrics:
+  enabled: false
+  image:
+    registry: docker.io
+    repository: bitnami/rabbitmq-exporter
+    tag: 0.29.0-debian-10-r38
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+  ## environment variables to configure rabbitmq_exporter
+  ## ref: https://github.com/kbudde/rabbitmq_exporter#configuration
+  env: {}
+  ## Metrics exporter port
+  port: 9419
+  ## RabbitMQ address to connect to (from the same Pod, usually the local loopback address).
+  ## If your Kubernetes cluster does not support IPv6, you can change to `127.0.0.1` in order to force IPv4.
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/#networking
+  rabbitmqAddress: localhost
+  ## Comma-separated list of extended scraping capabilities supported by the target RabbitMQ server
+  ## ref: https://github.com/kbudde/rabbitmq_exporter#extended-rabbitmq-capabilities
+  capabilities: "bert,no_sort"
+  resources: {}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9419"
+
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 15
+    timeoutSeconds: 5
+    periodSeconds: 30
+    failureThreshold: 6
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    timeoutSeconds: 5
+    periodSeconds: 30
+    failureThreshold: 3
+    successThreshold: 1
+
+  ## Prometheus Service Monitor
+  ## ref: https://github.com/coreos/prometheus-operator
+  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  serviceMonitor:
+    ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    enabled: false
+    ## Specify the namespace in which the serviceMonitor resource will be created
+    # namespace: ""
+    ## Specify the interval at which metrics should be scraped
+    interval: 30s
+    ## Specify the timeout after which the scrape is ended
+    # scrapeTimeout: 30s
+    ## Specify Metric Relabellings to add to the scrape endpoint
+    # relabellings:
+    ## Specify honorLabels parameter to add the scrape endpoint
+    honorLabels: false
+    ## Specify the release for ServiceMonitor. Sometimes it should be custom for prometheus operator to work
+    # release: ""
+    ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    additionalLabels: {}
+
+  ## Custom PrometheusRule to be defined
+  ## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
+  ## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+  prometheusRule:
+    enabled: false
+    additionalLabels: {}
+    namespace: ""
+    rules: []
+      ## List of reules, used as template by Helm.
+      ## These are just examples rules inspired from https://awesome-prometheus-alerts.grep.to/rules.html
+      ## Please adapt them to your needs.
+      ## Make sure to constraint the rules to the current rabbitmq service.
+      ## Also make sure to escape what looks like helm template.
+      # - alert: RabbitmqDown
+      #   expr: rabbitmq_up{service="{{ template "rabbitmq.fullname" . }}"} == 0
+      #   for: 5m
+      #   labels:
+      #     severity: error
+      #   annotations:
+      #     summary: Rabbitmq down (instance {{ "{{ $labels.instance }}" }})
+      #     description: RabbitMQ node down
+
+      # - alert: ClusterDown
+      #   expr: |
+      #     sum(rabbitmq_running{service="{{ template "rabbitmq.fullname" . }}"})
+      #     < {{ .Values.replicas }}
+      #   for: 5m
+      #   labels:
+      #     severity: error
+      #   annotations:
+      #     summary: Cluster down (instance {{ "{{ $labels.instance }}" }})
+      #     description: |
+      #         Less than {{ .Values.replicas }} nodes running in RabbitMQ cluster
+      #         VALUE = {{ "{{ $value }}" }}
+
+      # - alert: ClusterPartition
+      #   expr: rabbitmq_partitions{service="{{ template "rabbitmq.fullname" . }}"} > 0
+      #   for: 5m
+      #   labels:
+      #     severity: error
+      #   annotations:
+      #     summary: Cluster partition (instance {{ "{{ $labels.instance }}" }})
+      #     description: |
+      #         Cluster partition
+      #         VALUE = {{ "{{ $value }}" }}
+
+      # - alert: OutOfMemory
+      #   expr: |
+      #     rabbitmq_node_mem_used{service="{{ template "rabbitmq.fullname" . }}"}
+      #     / rabbitmq_node_mem_limit{service="{{ template "rabbitmq.fullname" . }}"}
+      #     * 100 > 90
+      #   for: 5m
+      #   labels:
+      #     severity: warning
+      #   annotations:
+      #     summary: Out of memory (instance {{ "{{ $labels.instance }}" }})
+      #     description: |
+      #         Memory available for RabbmitMQ is low (< 10%)\n  VALUE = {{ "{{ $value }}" }}
+      #         LABELS: {{ "{{ $labels }}" }}
+
+      # - alert: TooManyConnections
+      #   expr: rabbitmq_connectionsTotal{service="{{ template "rabbitmq.fullname" . }}"} > 1000
+      #   for: 5m
+      #   labels:
+      #     severity: warning
+      #   annotations:
+      #     summary: Too many connections (instance {{ "{{ $labels.instance }}" }})
+      #     description: |
+      #         RabbitMQ instance has too many connections (> 1000)
+      #         VALUE = {{ "{{ $value }}" }}\n  LABELS: {{ "{{ $labels }}" }}
+
+##
+## Init containers parameters:
+## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
+##
+volumePermissions:
+  enabled: false
+  image:
+    registry: docker.io
+    repository: bitnami/minideb
+    tag: buster
+    pullPolicy: Always
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+  resources: {}
+
+## forceBoot: executes 'rabbitmqctl force_boot' to force boot cluster shut down unexpectedly in an
+## unknown order.
+## ref: https://www.rabbitmq.com/rabbitmqctl.8.html#force_boot
+##
+forceBoot:
+  enabled: false
+
+## Optionally specify extra secrets to be created by the chart.
+## This can be useful when combined with load_definitions to automatically create the secret containing the definitions to be loaded.
+##
+extraSecrets: {}
+  # load-definition:
+  #   load_definition.json: |
+  #     {
+  #       ...
+  #     }

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/postgresql.tf
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/postgresql.tf
@@ -6,11 +6,11 @@ data "kubernetes_secret" "postgresql_core" {
 }
 resource "helm_release" "postgresql" {
   name      = "postgresql"
-  repository = "oci://registry-1.docker.io/bitnamicharts"
-  chart     = "postgresql"
+  #repository = "oci://registry-1.docker.io/bitnamicharts"
+  chart     = "${path.module}/charts/postgresql"
   namespace = "core"
-  version   = "18.3.0"
-  verify    = false # Temporarily necessery
+  #version   = "18.3.0"
+  #verify    = false # Temporarily necessery
 
   values = [
     file("${path.module}/postgresql_values/postgresql.yaml")

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/postgresql.tf
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/postgresql.tf
@@ -11,7 +11,6 @@ resource "helm_release" "postgresql" {
   namespace = "core"
   version   = "18.3.0"
   verify    = false # Temporarily necessery
-  timeout   = 1200
 
   values = [
     file("${path.module}/postgresql_values/postgresql.yaml")

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/postgresql_values/postgresql.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/postgresql_values/postgresql.yaml
@@ -7,7 +7,7 @@
 global:
   ## @param global.imageRegistry Global Docker image registry
   ##
-  imageRegistry: ""
+  #imageRegistry: ""
   ## @param global.imagePullSecrets Global Docker registry secret names as an array
   ## e.g.
   ## imagePullSecrets:
@@ -15,10 +15,10 @@ global:
   ##
   imagePullSecrets: []
   ## @param global.defaultStorageClass Global default StorageClass for Persistent Volume(s)
-## @param global.storageClass DEPRECATED: use global.defaultStorageClass instead
+  ## @param global.storageClass DEPRECATED: use global.defaultStorageClass instead
   ##
-  defaultStorageClass: ""
-  storageClass: ""
+  #defaultStorageClass: ""
+  #storageClass: ""
   ## Security parameters
   ##
   security:
@@ -66,16 +66,16 @@ global:
 
 ## @param kubeVersion Override Kubernetes version
 ##
-kubeVersion: ""
+#kubeVersion: ""
 ## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
 ##
-nameOverride: ""
+#nameOverride: "postgresql"
 ## @param fullnameOverride String to fully override common.names.fullname template
 ##
-fullnameOverride: ""
+fullnameOverride: "postgresql-postgresql"
 ## @param namespaceOverride String to fully override common.names.namespace
 ##
-namespaceOverride: ""
+#namespaceOverride: ""
 ## @param clusterDomain Kubernetes Cluster Domain
 ##
 clusterDomain: cluster.local
@@ -320,7 +320,11 @@ primary:
   ## @param primary.pgHbaConfiguration PostgreSQL Primary client authentication configuration
   ## ref: https://www.postgresql.org/docs/current/static/auth-pg-hba-conf.html
   ## e.g:#
-  ## pgHbaConfiguration: |-
+  #pgHbaConfiguration: |-
+  #  host  all   all   0.0.0.0/0   scram-sha-256
+    # Allow local connections
+  #  local all   all   trust
+
   ##   local all all trust
   ##   host all all localhost trust
   ##   host mydatabase mysuser 192.168.0.0/24 md5
@@ -333,7 +337,9 @@ primary:
   ## @param primary.extendedConfiguration Extended PostgreSQL Primary configuration (appended to main or default configuration)
   ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#allow-settings-to-be-loaded-from-files-other-than-the-default-postgresqlconf
   ##
-  # extendedConfiguration: ""
+  #extendedConfiguration: |-
+  #  hba_file = '/bitnami/postgresql/conf/pg_hba.conf'
+  
   ## @param primary.existingExtendedConfigmap Name of an existing ConfigMap with PostgreSQL Primary extended configuration
   ## NOTE: `primary.extendedConfiguration` will be ignored
   ##
@@ -498,7 +504,7 @@ primary:
   ## @param primary.podSecurityContext.fsGroup Group ID for the pod
   ##
   podSecurityContext:
-    enabled: false
+    enabled: true
     fsGroupChangePolicy: Always
     sysctls: []
     supplementalGroups: []
@@ -1613,8 +1619,8 @@ volumePermissions:
   ##
   image:
     registry: docker.io
-    #repository: bitnami/os-shell
-    #tag: 12-debian-12-r51
+    repository: bitnamilegacy/os-shell
+    tag: 12-debian-12-r51
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -1672,7 +1678,7 @@ serviceBindings:
 serviceAccount:
   ## @param serviceAccount.create Enable creation of ServiceAccount for PostgreSQL pod
   ##
-  create: true
+  create: false
   ## @param serviceAccount.name The name of the ServiceAccount to use.
   ## If not set and create is true, a name is generated using the common.names.fullname template
   ##

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/rabbitmq.tf
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/rabbitmq.tf
@@ -6,10 +6,11 @@ data "kubernetes_secret" "rabbitmq_core" {
 }
 resource "helm_release" "rabbitmq" {
   name      = "rabbitmq"
-  repository = "oci://registry-1.docker.io/bitnamicharts"
-  chart     = "rabbitmq"
+  #repository = "oci://registry-1.docker.io/bitnamicharts"
+  #chart     = "rabbitmq"
+  chart     = "${path.module}/charts/rabbitmq"
   namespace = "core"
-  version   = "16.0.14"
+  #version   = "16.0.14"
 
   values = [
     file("${path.module}/rabbitmq_values/rabbitmq.yaml")

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/rabbitmq.tf
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/rabbitmq.tf
@@ -10,7 +10,6 @@ resource "helm_release" "rabbitmq" {
   chart     = "rabbitmq"
   namespace = "core"
   version   = "16.0.14"
-  timeout   = 1200
 
   values = [
     file("${path.module}/rabbitmq_values/rabbitmq.yaml")

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/rabbitmq_values/rabbitmq.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/rabbitmq_values/rabbitmq.yaml
@@ -21,7 +21,7 @@ image:
   ## set to true if you would like to see extra information on logs
   ## it turns BASH and NAMI debugging in minideb
   ## ref:  https://github.com/bitnami/minideb-extras/#turn-on-bash-debugging
-  debug: false
+  debug: true
 
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -66,7 +66,7 @@ rbac:
 podManagementPolicy: OrderedReady
 
 ## section of specific values for rabbitmq
-auth:
+rabbitmq:
   ## RabbitMQ application username
   ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
   ##
@@ -89,60 +89,60 @@ auth:
   ##
   # rabbitmqClusterNodeName:
 
-## Value for the RABBITMQ_LOGS environment variable
-## ref: https://www.rabbitmq.com/logging.html#log-file-location
-##
-logs: '-'
+  ## Value for the RABBITMQ_LOGS environment variable
+  ## ref: https://www.rabbitmq.com/logging.html#log-file-location
+  ##
+  logs: '-'
 
-## RabbitMQ Max File Descriptors
-## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
-## ref: https://www.rabbitmq.com/install-debian.html#kernel-resource-limits
-##
-# setUlimitNofiles: true # No longer used it seems
-ulimitNofiles: '65536'
+  ## RabbitMQ Max File Descriptors
+  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ## ref: https://www.rabbitmq.com/install-debian.html#kernel-resource-limits
+  ##
+  # setUlimitNofiles: true # No longer used it seems
+  ulimitNofiles: '65536'
 
-## RabbitMQ maximum available scheduler threads and online scheduler threads
-## ref: https://hamidreza-s.github.io/erlang/scheduling/real-time/preemptive/migration/2016/02/09/erlang-scheduler-details.html#scheduler-threads
-##
-maxAvailableSchedulers: 2
-onlineSchedulers: 1
+  ## RabbitMQ maximum available scheduler threads and online scheduler threads
+  ## ref: https://hamidreza-s.github.io/erlang/scheduling/real-time/preemptive/migration/2016/02/09/erlang-scheduler-details.html#scheduler-threads
+  ##
+  maxAvailableSchedulers: 2
+  onlineSchedulers: 1
 
-## Plugins to enable
-plugins: "rabbitmq_management"
+  ## Plugins to enable
+  plugins: "rabbitmq_management"
 
-## Extra plugins to enable
-## Use this instead of `plugins` to add new plugins
-# extraPlugins: "rabbitmq_auth_backend_ldap"
+  ## Extra plugins to enable
+  ## Use this instead of `plugins` to add new plugins
+  # extraPlugins: "rabbitmq_auth_backend_ldap"
 
-## Clustering settings
-clustering:
-  address_type: hostname
-  #k8s_domain: cluster.local # Apparently no longer used
-  ## Rebalance master for queues in cluster when new replica is created
-  ## ref: https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
-  rebalance: false
+  ## Clustering settings
+  clustering:
+    address_type: hostname
+    #k8s_domain: cluster.local # Apparently no longer used
+    ## Rebalance master for queues in cluster when new replica is created
+    ## ref: https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
+    rebalance: false
 
-loadDefinition:
-  enabled: false
-  existingSecret: load-definition
+  loadDefinition:
+    enabled: false
+    existingSecret: load-definition
 
-## environment variables to configure rabbitmq
-## ref: https://www.rabbitmq.com/configure.html#customise-environment
-env: { }
+  ## environment variables to configure rabbitmq
+  ## ref: https://www.rabbitmq.com/configure.html#customise-environment
+  env: { }
 
-## Configuration file content: required cluster configuration
-## Do not override unless you know what you are doing. To add more configuration, use `extraConfiguration` of `advancedConfiguration` instead
-configuration: |-
-  # queue master locator
-  queue_master_locator=min-masters
-  # enable guest user
-  loopback_users.guest = false
+  ## Configuration file content: required cluster configuration
+  ## Do not override unless you know what you are doing. To add more configuration, use `extraConfiguration` of `advancedConfiguration` instead
+  configuration: |-
+    # queue master locator
+    queue_master_locator=min-masters
+    # enable guest user
+    loopback_users.guest = false
 
-## Configuration file content: extra configuration
-## Use this instead of `configuration` to add more configuration
-extraConfiguration: |-
-  #disk_free_limit.absolute = 50MB
-  #management.load_definitions = /app/load_definition.json
+  ## Configuration file content: extra configuration
+  ## Use this instead of `configuration` to add more configuration
+  extraConfiguration: |-
+    #disk_free_limit.absolute = 50MB
+    #management.load_definitions = /app/load_definition.json
 
   ## Configuration file content: advanced configuration
   ## Use this as additional configuraton in classic config format (Erlang term configuration format)
@@ -415,13 +415,14 @@ metrics:
 ## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
 ##
 volumePermissions:
-  enabled: false
+  enabled: true
 
 ## forceBoot: executes 'rabbitmqctl force_boot' to force boot cluster shut down unexpectedly in an
 ## unknown order.
 ## ref: https://www.rabbitmq.com/rabbitmqctl.8.html#force_boot
 ##
-forceBoot: false
+forceBoot:
+  enabled: false
 
 ## Optionally specify extra secrets to be created by the chart.
 ## This can be useful when combined with load_definitions to automatically create the secret containing the definitions to be loaded.

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/rabbitmq_values/rabbitmq.yaml
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/rabbitmq_values/rabbitmq.yaml
@@ -415,7 +415,7 @@ metrics:
 ## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
 ##
 volumePermissions:
-  enabled: true
+  enabled: false
 
 ## forceBoot: executes 'rabbitmqctl force_boot' to force boot cluster shut down unexpectedly in an
 ## unknown order.

--- a/terraform-k8s-infrastructure/modules/k8s_data_layer/redis.tf
+++ b/terraform-k8s-infrastructure/modules/k8s_data_layer/redis.tf
@@ -6,7 +6,6 @@ resource "helm_release" "redis" {
   chart     = "redis"
   namespace = "core"
   version   = "16.13.2"
-  timeout   = 1200
 
   values = [
     file("${path.module}/redis_values/redis.yaml")

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -306,3 +306,52 @@ resource "aws_eks_access_policy_association" "gha_policy" {
     aws_eks_access_entry.gha_role
   ]
 }
+
+# Default pod Service Account role and policy
+resource "aws_iam_role" "default_irsa" {
+  name = "default-irsa-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.example.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${replace(aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer, "https://", "")}:sub" = "system:serviceaccount:core:default"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "default_sa_policy" {
+  name        = "default-sa-policy-${var.environment}"
+  description = ""
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = "arn:aws:logs:us-east-1:*:log-group:*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "authorization_attach" {
+  role       = aws_iam_role.default_irsa.name
+  policy_arn = aws_iam_policy.default_irsa_policy.arn
+}

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -308,7 +308,7 @@ resource "aws_eks_access_policy_association" "gha_policy" {
 }
 
 # Default pod Service Account role and policy
-resource "aws_iam_role" "default_irsa" {
+resource "aws_iam_role" "default_sa_role" {
   name = "default-irsa-${var.environment}"
 
   assume_role_policy = jsonencode({
@@ -352,6 +352,6 @@ resource "aws_iam_policy" "default_sa_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "authorization_attach" {
-  role       = aws_iam_role.default_irsa.name
-  policy_arn = aws_iam_policy.default_irsa_policy.arn
+  role       = aws_iam_role.default_sa_role.name
+  policy_arn = aws_iam_policy.default_sa_policy.arn
 }


### PR DESCRIPTION
This PR imports the raw Helm Charts that are no longer available via the Bitnami Helm Chart repository, and makes the required modifications to ensure that the deployments still work using the new `bitnamilegacy` image.  The charts are in the `terraform-k8s-infrastructure/modules/k8s-data-layer/charts` folder, and don't need to be reviewed as they were copied unaltered from the original source.